### PR TITLE
feat: add ESlint configuration

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,96 @@
+{
+  "env": {
+    "es6": true,
+    "node": true,
+    "browser": true,
+    "jquery": true,
+    "jasmine": true,
+    "mocha": true,
+    "qunit": true
+  },
+  "overrides": [
+    {
+      "files": [ "**/*.js", "**/*.jsx", "**/*.es6", "**/*.mjs", "**/*.mdx" ],
+      "extends": "eslint:recommended",
+      "parserOptions": {
+        "ecmaFeatures": {
+          "jsx": true,
+          "globalReturn": true
+        },
+        "sourceType": "script"
+      },
+      "rules": {
+        "no-undef": "off",
+        "no-fallthrough": "off",
+        "no-mixed-spaces-and-tabs": "off",
+        "no-redeclare": "off",
+        "no-with": "off",
+        "no-prototype-builtins": "off",
+        "no-misleading-character-class": "off",
+        "no-async-promise-executor": "off",
+        "no-import-assign": "off",
+        "no-empty": [
+          "error",
+          { "allowEmptyCatch": true }
+        ],
+        "no-unused-vars": [
+          "warn",
+          {
+            "vars": "local",
+            "args": "after-used",
+            "ignoreRestSiblings": true
+          }
+        ],
+        "no-constant-condition": "off"
+      }
+    },
+    {
+      "files": [ "**/*.ts", "**/*.tsx" ],
+      "parser": "@typescript-eslint/parser",
+      "plugins": [ "@typescript-eslint" ],
+      "extends": [ "eslint:recommended", "plugin:@typescript-eslint/recommended" ],
+      "rules": {
+        "no-undef": "off",
+        "no-fallthrough": "off",
+        "no-mixed-spaces-and-tabs": "off",
+        "no-redeclare": "off",
+        "no-with": "off",
+        "no-prototype-builtins": "off",
+        "no-misleading-character-class": "off",
+        "no-async-promise-executor": "off",
+        "no-import-assign": "off",
+        "no-empty": [
+          "error",
+          { "allowEmptyCatch": true }
+        ],
+        "@typescript-eslint/no-unused-vars": [
+          "warn",
+          {
+            "vars": "local",
+            "args": "after-used",
+            "ignoreRestSiblings": true
+          }
+        ],
+        "@typescript-eslint/prefer-as-const": "off",
+        "@typescript-eslint/no-empty-function": "off",
+        "@typescript-eslint/no-empty-interface": "off",
+        "@typescript-eslint/no-inferrable-types": "off",
+        "@typescript-eslint/no-namespace": "off",
+        "@typescript-eslint/no-non-null-assertion": "off",
+        "@typescript-eslint/no-this-alias": "off",
+        "@typescript-eslint/no-unnecessary-type-constraint": "off",
+        "@typescript-eslint/no-var-requires": "off",
+        "@typescript-eslint/triple-slash-reference": "off",
+        "@typescript-eslint/prefer-namespace-keyword": "off"
+      }
+    }
+  ],
+  "globals": {
+    "ActiveXObject": true,
+    "XDomainRequest": true,
+    "ScriptEngine": true,
+    "WSH": true,
+    "WScript": true,
+    "DocumentTouch": true
+  }
+}


### PR DESCRIPTION
Adds an initial ESlint configuration to be used by CodeFactor CI.
Disables `no-unused-vars` for rest siblings (object destructuring) and `no-constant-condition`.