### PR TITLE
fix(demo): setup ordering rc releases above stable ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,8 +175,8 @@ USAGE
   $ conduit init
 
 OPTIONS
-  -h, --help             show CLI help
-  -r, --relogin=relogin  Reuses url and master key
+  -h, --help     show CLI help
+  -r, --relogin  Reuses url and master key from existing configuration
 
 EXAMPLE
   $ conduit init

--- a/src/commands/demo/setup.ts
+++ b/src/commands/demo/setup.ts
@@ -278,7 +278,7 @@ export default class DemoSetup extends Command {
     });
     releases.sort().reverse();
     rcReleases.sort().reverse();
-    releases.push.apply(releases, rcReleases);
+    releases.push(...rcReleases);
     releases.push('latest');
     return releases;
   }

--- a/src/commands/demo/setup.ts
+++ b/src/commands/demo/setup.ts
@@ -268,8 +268,17 @@ export default class DemoSetup extends Command {
       { headers: { Accept: 'application/vnd.github.v3+json' } },
     );
     const releases: string[] = [];
-    res.data.forEach((release: any) => { releases.push(release.tag_name); });
+    const rcReleases: string[] = [];
+    res.data.forEach((release: any) => {
+      if (release.tag_name.indexOf('-rc') === -1) {
+        releases.push(release.tag_name);
+      } else {
+        rcReleases.push(release.tag_name);
+      }
+    });
     releases.sort().reverse();
+    rcReleases.sort().reverse();
+    releases.push.apply(releases, rcReleases);
     releases.push('latest');
     return releases;
   }


### PR DESCRIPTION
Makes it so rc releases are always ordered below stable tags.
Also fixes `init --relogin` boolean flag described as a string arg (leftover).