### PR TITLE
fix(demo): fallback ports setting incorrect internal port mapping

### DIFF
--- a/src/commands/demo/start.ts
+++ b/src/commands/demo/start.ts
@@ -40,9 +40,12 @@ export default class DemoStart extends Command {
     return formatted;
   }
 
-  private formatPorts(ports: PackageConfiguration['ports']) {
+  private formatPorts(portBindings: PackageConfiguration['ports']) {
     const formatted: { [key: string]: { 'HostPort': string }[] } = {};
-    ports.forEach(port => { formatted[`${port}/tcp`] = [{ 'HostPort': port }]; });
+    portBindings.forEach(portBinding => {
+      const [hostPort, containerPort] = portBinding.split(':');
+      formatted[`${containerPort}/tcp`] = [{ 'HostPort': hostPort }];
+    });
     return formatted;
   }
 }

--- a/src/utils/getPort.ts
+++ b/src/utils/getPort.ts
@@ -88,7 +88,7 @@ const portCheckSequence = function * (ports: Iterable<number> | undefined) {
   yield 0; // Fall back to 0 if anything else failed
 };
 
-export async function getPorts(options: Options): Promise<number> {
+export async function getPort(options: Options): Promise<number> {
   let ports;
   let exclude = new Set();
 


### PR DESCRIPTION
This fixes port bindings specifying an incorrect internal port while mapping using a fallback port number.
Ports for Redis, Mongo and Postgres are still exposed on the host so that users can conveniently access their data.

**Running this requires generating a new demo configuration.**