### PR TITLE
fix(demo): exposed ports, network name, database credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ $ npm install -g @conduitplatform/conduit-cli
 $ conduit COMMAND
 running command...
 $ conduit (--version|-v)
-@conduitplatform/conduit-cli/latest linux-x64 node-v14.19.0
+@conduitplatform/conduit-cli/0.0.2 darwin-x64 node-v18.4.0
 $ conduit --help [COMMAND]
 USAGE
   $ conduit COMMAND
@@ -126,11 +126,11 @@ Generates a REST API client library for Conduit'S REST API
 
 ```
 USAGE
-  $ conduit generateClient rest [--client-type <value>] [--output-path <value>]
+  $ conduit generateClient rest [-t <value>] [-p <value>]
 
 FLAGS
-  --client-type=<value>  The client type to generate a library for
-  --output-path=<value>  Path to store archived library in
+  -p, --output-path=<value>  Path to store archived library in
+  -t, --client-type=<value>  The client type to generate a library for
 
 DESCRIPTION
   Generates a REST API client library for Conduit'S REST API
@@ -142,10 +142,7 @@ Generate Schema TS files for registered Conduit schemas
 
 ```
 USAGE
-  $ conduit generateSchema [PATH] [-h]
-
-FLAGS
-  -h, --help  Show CLI help.
+  $ conduit generateSchema [PATH]
 
 DESCRIPTION
   Generate Schema TS files for registered Conduit schemas
@@ -156,7 +153,7 @@ EXAMPLES
   Generating schemas
 ```
 
-_See code: [src/commands/generateSchema.ts](https://github.com/ConduitPlatform/CLI/blob/main/src/commands/generateSchema.ts)_
+_See code: [dist/commands/generateSchema.ts](https://github.com/ConduitPlatform/CLI/blob/v0.0.2/dist/commands/generateSchema.ts)_
 
 ## `conduit help [COMMAND]`
 
@@ -184,10 +181,9 @@ Initialize the CLI to communicate with Conduit
 
 ```
 USAGE
-  $ conduit init [-h] [-r]
+  $ conduit init [-r]
 
 FLAGS
-  -h, --help     Show CLI help.
   -r, --relogin  Reuses url and master key from existing configuration
 
 DESCRIPTION
@@ -200,7 +196,7 @@ EXAMPLES
   Login Successful!
 ```
 
-_See code: [src/commands/init.ts](https://github.com/ConduitPlatform/CLI/blob/main/src/commands/init.ts)_
+_See code: [dist/commands/init.ts](https://github.com/ConduitPlatform/CLI/blob/v0.0.2/dist/commands/init.ts)_
 <!-- commandsstop -->
 
 #Roadmap

--- a/src/commands/demo/setup.ts
+++ b/src/commands/demo/setup.ts
@@ -269,10 +269,10 @@ export default class DemoSetup extends Command {
       }
     });
     // Display Information
-    console.log(`\n\nDatabase Credentials for ${this.selectedDbEngine === 'mongodb' ? 'MongoDB' : 'PostgreSQL'}:`);
+    console.log(`\nDatabase Credentials for ${this.selectedDbEngine === 'mongodb' ? 'MongoDB' : 'PostgreSQL'}:`);
     console.log(`Username:\t${this.dbUsername}`);
     console.log(`Password:\t${this.dbPassword}`);
-    console.log('\n\n');
+    console.log('\n');
   }
 
   private sortPackages() {

--- a/src/commands/demo/setup.ts
+++ b/src/commands/demo/setup.ts
@@ -123,7 +123,7 @@ export default class DemoSetup extends Command {
   private selectedPackages: Package[] = ['Core', 'UI', 'Database', 'Authentication', 'Redis'];
   private conduitTags: string[] = [];
   private conduitUiTags: string[] = [];
-  private selectedDbEngine: 'mongodb' | 'postgresql' = 'mongodb';
+  private selectedDbEngine: 'mongodb' | 'postgres' = 'mongodb';
   private selectedConduitTag: string = '';
   private selectedConduitUiTag: string = '';
   private demoConfiguration: ConduitPackageConfiguration = {
@@ -202,6 +202,7 @@ export default class DemoSetup extends Command {
       false,
     );
     this.selectedPackages.push(dbEngineType === 'mongodb' ? 'Mongo' : 'Postgres');
+    this.selectedDbEngine = dbEngineType === 'mongodb' ? 'mongodb' : 'postgres';
 
     // Specify DB Engine Credentials
     this.dbUsername = await CliUx.ux.prompt('Specify database username', { default: 'conduit' });
@@ -250,8 +251,8 @@ export default class DemoSetup extends Command {
       dbHost = 'conduit-postgres';
       dbPort = this.demoConfiguration.packages['Postgres'].ports[0].split(':')[1];
       dbDatabase = 'conduit';
-      this.demoConfiguration.packages['Mongo'].env['POSTGRES_USER'] = this.dbUsername;
-      this.demoConfiguration.packages['Mongo'].env['POSTGRES_PASSWORD'] = this.dbPassword;
+      this.demoConfiguration.packages['Postgres'].env['POSTGRES_USER'] = this.dbUsername;
+      this.demoConfiguration.packages['Postgres'].env['POSTGRES_PASSWORD'] = this.dbPassword;
     }
     this.demoConfiguration.packages['Database'].env = {
       ...this.demoConfiguration.packages['Database'].env,

--- a/src/commands/demo/setup.ts
+++ b/src/commands/demo/setup.ts
@@ -106,6 +106,7 @@ const DEMO_CONFIG: { [key: string]: Pick<PackageConfiguration, 'env' | 'ports'> 
     env: {
       POSTGRES_USER: '',
       POSTGRES_PASSWORD: '',
+      POSTGRES_DB: 'conduit',
     },
     ports: ['5432'],
   },

--- a/src/commands/demo/setup.ts
+++ b/src/commands/demo/setup.ts
@@ -4,7 +4,7 @@ import {
   POSTGRES_VERSION,
 } from '../../demo/constants';
 import { getContainerName, getImageName, demoIsDeployed } from '../../demo/utils';
-import { ConduitPackageConfiguration, Package, PackageConfiguration } from '../../demo/types';
+import { ConduitPackageConfiguration, Package, Image, PackageConfiguration } from '../../demo/types';
 import { booleanPrompt, promptWithOptions } from '../../utils/cli';
 import { getPort, portNumbers } from '../../utils/getPort';
 import { Docker } from '../../docker/Docker';
@@ -193,7 +193,20 @@ export default class DemoSetup extends Command {
       false,
     );
     this.selectedPackages.push(dbEngineType === 'mongodb' ? 'Mongo' : 'Postgres');
+
+    // Specify DB Engine Credentials
+    const dbUsername = await CliUx.ux.prompt('Specify database username', { default: 'conduit' });
+    const dbPassword = await CliUx.ux.prompt('Specify database password', { default: 'pass' });
+    if (dbEngineType === 'mongodb') {
+      this.demoConfiguration.packages['Mongo'].env.MONGO_INITDB_ROOT_USERNAME = dbUsername;
+      this.demoConfiguration.packages['Mongo'].env.MONGO_INITDB_ROOT_PASSWORD = dbPassword;
+    } else {
+      this.demoConfiguration.packages['Postgres'].env.POSTGRES_PASSWORD = dbPassword;
+      this.demoConfiguration.packages['Postgres'].env.POSTGRES_USER = dbUsername;
+    }
   }
+
+
 
   private async processConfiguration() {
     this.sortPackages();

--- a/src/commands/demo/setup.ts
+++ b/src/commands/demo/setup.ts
@@ -271,6 +271,11 @@ export default class DemoSetup extends Command {
         this.demoConfiguration.packages[pkg].env['CONDUIT_SERVER'] = `${getContainerName('Core')}:${conduitGrpcPort}`;
       }
     });
+    // Display Information
+    console.log(`\n\nDatabase Credentials for ${this.selectedDbEngine === 'mongodb' ? 'MongoDB' : 'PostgreSQL'}:`);
+    console.log(`Username:\t${dbUsername}`);
+    console.log(`Password:\t${dbPassword}`);
+    console.log('\n\n');
   }
 
   private sortPackages() {

--- a/src/commands/demo/setup.ts
+++ b/src/commands/demo/setup.ts
@@ -217,7 +217,6 @@ export default class DemoSetup extends Command {
     console.log('\nSetting up container environment. This may take some time...')
     for (const pkg of this.selectedPackages) {
       const containerName = getContainerName(pkg);
-      // console.log(DEMO_CONFIG[pkg]);
       this.demoConfiguration.packages[pkg] = {
         image: getImageName(pkg),
         tag: pkg === 'Redis' ? REDIS_VERSION

--- a/src/docker/Docker.ts
+++ b/src/docker/Docker.ts
@@ -49,7 +49,7 @@ export class Docker {
     };
     await promisifiedPull(this.docker, repoTag);
   }
-  
+
   async run(
     packageName: Package,
     tag: string,
@@ -66,11 +66,16 @@ export class Docker {
       return;
     }
     if (!silent) console.log(`Running ${packageName}`);
+    const exposedPorts:any = {};
+    Object.keys(ports).forEach(port => {
+      exposedPorts[`${port}`] = {};
+    });
     await this.docker.createContainer({
       Image: `${getImageName(packageName)}:${tag}`,
       Cmd: [],
       'name': getContainerName(packageName),
       'Env': env ?? [],
+      'ExposedPorts': exposedPorts,
       'HostConfig': {
         'NetworkMode': this.networkName,
         'PortBindings': ports,
@@ -86,7 +91,7 @@ export class Docker {
     });
     await this.start(packageName, true, true);
   }
-  
+
   async start(packageName: Package, silent = false, bypassExistCheck = false) {
     if (!bypassExistCheck) await this.containerExists(packageName, true);
     const isRunning = await this.containerExists(packageName, false, true);
@@ -98,7 +103,7 @@ export class Docker {
     const container = this.docker.getContainer(getContainerName(packageName));
     await container.start();
   }
-  
+
   async stop(packageName: Package, silent = false, bypassExistCheck = false) {
     if (!bypassExistCheck) await this.containerExists(packageName, false);
     const isRunning = await this.containerExists(packageName, false, true);
@@ -110,7 +115,7 @@ export class Docker {
     const container = this.docker.getContainer(getContainerName(packageName));
     await container.stop();
   }
-  
+
   async rm(packageName: Package, silent = false, bypassExistCheck = false) {
     const exists = bypassExistCheck || await this.containerExists(packageName);
     if (exists) {
@@ -118,7 +123,7 @@ export class Docker {
       await this.docker.getContainer(getContainerName(packageName)).remove();
     }
   }
-  
+
   async rmi(packageName: Package, tag: string, silent = false, bypassExistCheck = false) {
     const exists = bypassExistCheck || await this.imageExists(packageName, tag);
     if (exists) {

--- a/src/docker/Docker.ts
+++ b/src/docker/Docker.ts
@@ -66,7 +66,7 @@ export class Docker {
       return;
     }
     if (!silent) console.log(`Running ${packageName}`);
-    const exposedPorts:any = {};
+    const exposedPorts: {[p: string]: Record<string, unknown>} = {};
     Object.keys(ports).forEach(port => {
       exposedPorts[`${port}`] = {};
     });

--- a/src/docker/Docker.ts
+++ b/src/docker/Docker.ts
@@ -77,7 +77,7 @@ export class Docker {
       },
       'NetworkingConfig': {
         'EndpointsConfig': {
-          'conduit': { 'Aliases': [packageName.toLowerCase()] },
+          [this.networkName]: { 'Aliases': [packageName.toLowerCase()] },
         },
       },
     }).catch((e) => {

--- a/src/docker/Docker.ts
+++ b/src/docker/Docker.ts
@@ -127,7 +127,7 @@ export class Docker {
   async rmi(packageName: Package, tag: string, silent = false, bypassExistCheck = false) {
     const exists = bypassExistCheck || await this.imageExists(packageName, tag);
     if (exists) {
-      if (!silent) console.log(`Removing ${packageName} container`)
+      if (!silent) console.log(`Removing ${packageName} image`)
       const repoTag = `${getImageName(packageName)}:${tag}`;
       const repoTagSlim = repoTag.substring(repoTag.lastIndexOf('/') + 1);
       const image = (await this.docker.listImages()).some(img => { return img.RepoTags?.includes(repoTag) })


### PR DESCRIPTION
This PR introduces the following fixes and changes:

- [X] PostgreSQL hostname now uses container name (previously worked through exposed ports)
- [X] PostgreSQL credentials are now properly set
- [X] Database credentials used are clearly displayed during `demo setup`.
- [X] Fixed port bindings not exposed properly
- [X] Fixed leftover hardcoded container network name

Both Mongo and Postgres databases now make use of user credentials.