### PR TITLE
fix(deploy): attempting to pull compose files from branch for latest releases

### DIFF
--- a/src/commands/deploy/setup.ts
+++ b/src/commands/deploy/setup.ts
@@ -75,7 +75,12 @@ export class DeploySetup extends Command {
       this.selectedTag,
     );
     const tagPrefix = this.selectedTag.slice(1).split('.').slice(0, 2).join('.');
-    if (!isNaN(parseFloat(tagPrefix)) && parseFloat(tagPrefix) < 0.15) {
+    if (this.conduitTags[0].startsWith(`v${tagPrefix}`)) {
+      manifestUrl =
+        'https://raw.githubusercontent.com/ConduitPlatform/Conduit/main/docker/docker-compose.yml';
+      envUrl =
+        'https://raw.githubusercontent.com/ConduitPlatform/Conduit/main/docker/.env';
+    } else if (!isNaN(parseFloat(tagPrefix)) && parseFloat(tagPrefix) < 0.15) {
       const targetBranch = `v${tagPrefix}.x`;
       manifestUrl = `https://raw.githubusercontent.com/ConduitPlatform/Conduit/${targetBranch}/docker/docker-compose.yml`;
       envUrl = `https://raw.githubusercontent.com/ConduitPlatform/Conduit/${targetBranch}/docker/.env`;


### PR DESCRIPTION
Latest releases are not yet branched into a `v0.XX.x` branch, thus attempting to pull `v0.14.0` from `v0.14.x` would fail.
Deploy setup now pulls from `main` for latest tags (works with minor versions).