### PR TITLE
fix: commands with topics have inaccurate descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ $ npm install -g @conduitplatform/cli
 $ conduit COMMAND
 running command...
 $ conduit (--version|-v)
-@conduitplatform/cli/0.0.2 linux-x64 node-v16.15.0
+@conduitplatform/cli/0.0.4 linux-x64 node-v16.15.0
 $ conduit --help [COMMAND]
 USAGE
   $ conduit COMMAND
@@ -66,7 +66,7 @@ DESCRIPTION
 
 ## `conduit deploy setup`
 
-Bootstraps a local Conduit deployment
+Bootstrap a local Conduit deployment
 
 ```
 USAGE
@@ -76,7 +76,7 @@ FLAGS
   --config  Enable manual deployment configuration
 
 DESCRIPTION
-  Bootstraps a local Conduit deployment
+  Bootstrap a local Conduit deployment
 ```
 
 ## `conduit deploy start`
@@ -111,7 +111,7 @@ DESCRIPTION
 
 ## `conduit generateClient graphql`
 
-Generates a GraphQL client library for Conduit's GraphQL API
+Generate a GraphQL client library for Conduit's GraphQL API
 
 ```
 USAGE
@@ -122,12 +122,12 @@ FLAGS
   -t, --client-type=<value>  The client type to generate a library for
 
 DESCRIPTION
-  Generates a GraphQL client library for Conduit's GraphQL API
+  Generate a GraphQL client library for Conduit's GraphQL API
 ```
 
 ## `conduit generateClient rest`
 
-Generates a REST API client library for Conduit'S REST API
+Generate a REST API client library for Conduit'S REST API
 
 ```
 USAGE
@@ -138,7 +138,7 @@ FLAGS
   -t, --client-type=<value>  The client type to generate a library for
 
 DESCRIPTION
-  Generates a REST API client library for Conduit'S REST API
+  Generate a REST API client library for Conduit'S REST API
 ```
 
 ## `conduit generateSchema [PATH]`
@@ -158,7 +158,7 @@ EXAMPLES
   Generating schemas
 ```
 
-_See code: [dist/commands/generateSchema.ts](https://github.com/ConduitPlatform/CLI/blob/v0.0.2/dist/commands/generateSchema.ts)_
+_See code: [dist/commands/generateSchema.ts](https://github.com/ConduitPlatform/CLI/blob/v0.0.4/dist/commands/generateSchema.ts)_
 
 ## `conduit help [COMMAND]`
 
@@ -201,7 +201,7 @@ EXAMPLES
   Login Successful!
 ```
 
-_See code: [dist/commands/init.ts](https://github.com/ConduitPlatform/CLI/blob/v0.0.2/dist/commands/init.ts)_
+_See code: [dist/commands/init.ts](https://github.com/ConduitPlatform/CLI/blob/v0.0.4/dist/commands/init.ts)_
 <!-- commandsstop -->
 
 # Roadmap

--- a/package.json
+++ b/package.json
@@ -85,6 +85,10 @@
     ],
     "macos": {
       "identifier": "dev.getconduit.cli"
+    },
+    "topics": {
+      "deploy": { "description": "Deploy and manage local Conduit instances" },
+      "generateClient": { "description": "Generate client libraries for your Conduit APIs" }
     }
   },
   "repository": {

--- a/src/commands/deploy/setup.ts
+++ b/src/commands/deploy/setup.ts
@@ -8,7 +8,7 @@ import * as fs from 'fs-extra';
 import * as yaml from 'js-yaml';
 
 export class DeploySetup extends Command {
-  static description = 'Bootstraps a local Conduit deployment';
+  static description = 'Bootstrap a local Conduit deployment';
   static flags = {
     config: Flags.boolean({
       description: 'Enable manual deployment configuration',

--- a/src/commands/generateClient/graphql.ts
+++ b/src/commands/generateClient/graphql.ts
@@ -14,24 +14,29 @@ type CONFIG_OPTIONS_BASE_T =
   | 'enumsAsTypes'
   | 'fragmentMasking';
 
-type CONFIG_OPTIONS_REACT_APOLLO_T =
-  | 'reactApolloVersion'
-  | 'operationResultSuffix';
+type CONFIG_OPTIONS_REACT_APOLLO_T = 'reactApolloVersion' | 'operationResultSuffix';
 
-export default class GenerateClientGraphql extends Command {
-  static description = `Generates a GraphQL client library for Conduit's GraphQL API`;
+export class GenerateClientGraphql extends Command {
+  static description = 'Generate client libraries for your Conduit GraphQL APIs';
   static flags = {
     'client-type': Flags.string({
       char: 't',
-      description: 'The client type to generate a library for'
+      description: 'The client type to generate a library for',
     }),
     'output-path': Flags.string({
       char: 'p',
       description: 'Path to store archived library in',
     }),
-  }
-  private supportedClientTypes: string[] =
-    ['typescript', 'react', 'react-apollo', 'angular', 'vue-urql', 'vue-apollo', 'svelte'];
+  };
+  private supportedClientTypes: string[] = [
+    'typescript',
+    'react',
+    'react-apollo',
+    'angular',
+    'vue-urql',
+    'vue-apollo',
+    'svelte',
+  ];
   private genConfig: { [field: string]: string | boolean } = {};
   private fileNameSuffix: string = '';
 
@@ -93,7 +98,7 @@ export default class GenerateClientGraphql extends Command {
   }
 
   private async getConfig(clientType: string) {
-    console.log('Configure client library configuration options:')
+    console.log('Configure client library configuration options:');
     for (const opt of this.baseConfigOptions) {
       this.genConfig[opt] = await booleanPrompt(opt);
     }
@@ -129,7 +134,7 @@ export default class GenerateClientGraphql extends Command {
         this.fileNameSuffix = `types.svelte-apollo.${this.fileNameSuffix}.ts`;
         return ['typescript', 'typescript-operations', 'graphql-codegen-svelte-apollo'];
       default:
-        console.error( 'Invalid Plugin');
+        console.error('Invalid Plugin');
         CliUx.ux.exit(-1);
     }
   }

--- a/src/commands/generateClient/rest.ts
+++ b/src/commands/generateClient/rest.ts
@@ -4,18 +4,18 @@ import { getClientType, getOutputPath, getBaseUrl } from '../../utils/generateCl
 import * as fs from 'fs';
 const { execSync } = require('child_process');
 
-export default class GenerateClientRest extends Command {
-  static description = `Generates a REST API client library for Conduit'S REST API`;
+export class GenerateClientRest extends Command {
+  static description = 'Generate client libraries for your Conduit REST APIs';
   static flags = {
     'client-type': Flags.string({
       char: 't',
-      description: 'The client type to generate a library for'
+      description: 'The client type to generate a library for',
     }),
     'output-path': Flags.string({
       char: 'p',
       description: 'Path to store archived library in',
     }),
-  }
+  };
   private supportedClientTypes: string[] = [];
 
   async run() {
@@ -27,7 +27,9 @@ export default class GenerateClientRest extends Command {
     }
     const url = await getBaseUrl(this);
     const parsedFlags = (await this.parse(GenerateClientRest)).flags;
-    console.log(`Conduit's REST API supports both application and administration requests.`);
+    console.log(
+      `Conduit's REST API supports both application and administration requests.`,
+    );
     const requestType = (await promptWithOptions(
       'Specify target request type',
       ['app', 'admin'],
@@ -36,11 +38,11 @@ export default class GenerateClientRest extends Command {
     this.getSupportedClientTypes();
     const clientType = await getClientType(parsedFlags, this.supportedClientTypes);
     const libPath = await getOutputPath(parsedFlags, 'rest', requestType);
-    const inputSpec = (requestType === 'admin') ? 'admin/swagger.json' : 'swagger.json';
+    const inputSpec = requestType === 'admin' ? 'admin/swagger.json' : 'swagger.json';
     try {
       execSync(
         `npx @openapitools/openapi-generator-cli generate \
-        -i ${url}/${inputSpec} -g ${clientType} -o ${libPath} --skip-validate-spec`
+        -i ${url}/${inputSpec} -g ${clientType} -o ${libPath} --skip-validate-spec`,
       );
       const zipPath = await this.convertToZip(libPath);
       console.log(`\nClient library archive available in: ${zipPath}`);
@@ -51,12 +53,12 @@ export default class GenerateClientRest extends Command {
   }
 
   private async convertToZip(libPath: string) {
-    const zipPath = `${libPath}.zip`
+    const zipPath = `${libPath}.zip`;
     execSync(`zip -r ${zipPath} ${libPath}`);
-    fs.rm(libPath, { recursive: true, force: true }, (err) => {
+    fs.rm(libPath, { recursive: true, force: true }, err => {
       if (err) {
-        console.error(err)
-        return
+        console.error(err);
+        return;
       }
     });
     return zipPath;
@@ -64,8 +66,11 @@ export default class GenerateClientRest extends Command {
 
   private getSupportedClientTypes() {
     try {
-      this.supportedClientTypes = execSync('npx @openapitools/openapi-generator-cli list -s')
-        .toString().split(',');
+      this.supportedClientTypes = execSync(
+        'npx @openapitools/openapi-generator-cli list -s',
+      )
+        .toString()
+        .split(',');
     } catch (error) {
       console.error(error);
       CliUx.ux.exit(-1);
@@ -74,7 +79,9 @@ export default class GenerateClientRest extends Command {
 
   private getJavaVersion() {
     try {
-      const javaVersion = execSync('java --version 2> /dev/null').toString().split(' ')[1];
+      const javaVersion = execSync('java --version 2> /dev/null')
+        .toString()
+        .split(' ')[1];
       console.log(javaVersion);
       return javaVersion;
     } catch (error) {

--- a/src/commands/generateSchema.ts
+++ b/src/commands/generateSchema.ts
@@ -3,7 +3,7 @@ import { getRequestClient } from '../utils/requestUtils';
 import { Requests } from '../http/http';
 import { generateSchema } from '../generators/Schema/Schema.generator';
 
-export default class GenerateSchema extends Command {
+export class GenerateSchema extends Command {
   static description = 'Generate Schema TS files for registered Conduit schemas';
 
   static examples = [

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -2,7 +2,7 @@ import { Command, Flags, CliUx } from '@oclif/core';
 import { Requests } from '../http/http';
 import { recoverApiConfig, storeConfiguration } from '../utils/requestUtils';
 
-export default class Init extends Command {
+export class Init extends Command {
   static description = 'Initialize the CLI to communicate with Conduit';
 
   static examples = [
@@ -14,7 +14,10 @@ Login Successful!
   ];
 
   static flags = {
-    relogin: Flags.boolean({ char: 'r', description: 'Reuses url and master key from existing configuration' }),
+    relogin: Flags.boolean({
+      char: 'r',
+      description: 'Reuses url and master key from existing configuration',
+    }),
   };
 
   async run() {
@@ -31,7 +34,9 @@ Login Successful!
         url = await CliUx.ux.prompt('Specify the API url of your Conduit installation');
       }
       if (!masterKey) {
-        masterKey = await CliUx.ux.prompt('Add the master key of your Conduit installation');
+        masterKey = await CliUx.ux.prompt(
+          'Add the master key of your Conduit installation',
+        );
       }
       requestInstance = new Requests(this, url, masterKey);
       const pingSuccessful = await requestInstance.httpHealthCheck();


### PR DESCRIPTION
Oclif commands with topics (subcommands) pick up the first topic description to be used as their own while no description of their own is explicitly specified.

This fixes the above and updates a few of our descriptions.
Any formatting changes are due to Prettier.