### PR TITLE
feat(deploy): warn about docker-compose incompatibility

### DIFF
--- a/src/commands/deploy/rm.ts
+++ b/src/commands/deploy/rm.ts
@@ -1,6 +1,10 @@
 import { Command, Flags, CliUx } from '@oclif/core';
 import dockerCompose from 'docker-compose';
-import { listLocalDeployments, getDeploymentPaths } from '../../deploy/utils';
+import {
+  assertDockerComposeCompat,
+  listLocalDeployments,
+  getDeploymentPaths,
+} from '../../deploy/utils';
 import * as fs from 'fs';
 
 export class DeployRemove extends Command {
@@ -15,6 +19,7 @@ export class DeployRemove extends Command {
   private deploymentPath!: string;
 
   async run() {
+    assertDockerComposeCompat();
     // Select Target Deployment
     let target = (await this.parse(DeployRemove)).flags.target;
     if (!target) {

--- a/src/commands/deploy/start.ts
+++ b/src/commands/deploy/start.ts
@@ -1,7 +1,11 @@
 import { Command, Flags, CliUx } from '@oclif/core';
 import dockerCompose from 'docker-compose';
 import { DeploymentConfiguration } from '../../deploy/types';
-import { listLocalDeployments, getDeploymentPaths } from '../../deploy/utils';
+import {
+  assertDockerComposeCompat,
+  listLocalDeployments,
+  getDeploymentPaths,
+} from '../../deploy/utils';
 import * as fs from 'fs-extra';
 import * as dotenv from 'dotenv';
 import * as open from 'open';
@@ -18,6 +22,7 @@ export class DeployStart extends Command {
   private deploymentConfig!: DeploymentConfiguration;
 
   async run() {
+    assertDockerComposeCompat();
     // Select Target Deployment
     let target = (await this.parse(DeployStart)).flags.target;
     if (!target) {

--- a/src/commands/deploy/stop.ts
+++ b/src/commands/deploy/stop.ts
@@ -1,6 +1,10 @@
 import { Command, Flags, CliUx } from '@oclif/core';
 import dockerCompose from 'docker-compose';
-import { listLocalDeployments, getDeploymentPaths } from '../../deploy/utils';
+import {
+  assertDockerComposeCompat,
+  listLocalDeployments,
+  getDeploymentPaths,
+} from '../../deploy/utils';
 
 export class DeployStop extends Command {
   static description = 'Bring down a local Conduit deployment';
@@ -12,6 +16,7 @@ export class DeployStop extends Command {
   };
 
   async run() {
+    assertDockerComposeCompat();
     // Select Target Deployment
     let target = (await this.parse(DeployStop)).flags.target;
     if (!target) {

--- a/src/deploy/utils.ts
+++ b/src/deploy/utils.ts
@@ -48,6 +48,13 @@ export function assertDockerComposeCompat() {
     }).toString();
     if (composeVersionString.startsWith('docker-compose version')) return;
   } catch {}
+  try {
+    // Aliased v2
+    const composeVersionString = execSync('docker-compose version', {
+      stdio: [],
+    }).toString();
+    if (composeVersionString.startsWith('Docker Compose version')) return;
+  } catch {}
   let exit = false;
   try {
     const output = execSync('docker compose --help', { stdio: [] }).toString();


### PR DESCRIPTION
This PR introduces a warning regarding lack of support for docker's compose v2 (golang plugin).
This is a temporary solution until we figure out how best to support v1/v2.