### PR TITLE
feat(generateClient): GraphQL Admin Client Generation and overall fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,16 @@ The CLI to help you when developing conduit.
 [//]: # ([![License]&#40;https://img.shields.io/npm/l/conduit-cli.svg&#41;]&#40;https://github.com/ConduitPlatform/CLI/blob/main/package.json&#41;)
 
 <!-- toc -->
-* [Limitations:](#limitations)
+* [Limitations](#limitations)
 * [Usage](#usage)
 * [Commands](#commands)
 * [Roadmap](#roadmap)
 <!-- tocstop -->
 
-# Limitations:
-* Currently, only creates schemas and only for TypeScript
+# Limitations
+
+While the CLI is capable of bootstrapping any Conduit release, including legacy ones,
+ `generateSchema` and `generateClient` commands currently require that you target >= v0.14.5.
 
 # Usage
 <!-- usage -->
@@ -29,7 +31,7 @@ $ npm install -g @conduitplatform/cli
 $ conduit COMMAND
 running command...
 $ conduit (--version|-v)
-@conduitplatform/cli/0.0.6 linux-x64 node-v16.15.0
+@conduitplatform/cli/0.0.7 linux-x64 node-v16.15.0
 $ conduit --help [COMMAND]
 USAGE
   $ conduit COMMAND
@@ -189,7 +191,7 @@ USAGE
   $ conduit init [-r]
 
 FLAGS
-  -r, --relogin  Reuses url and master key from existing configuration
+  -r, --relogin  Reuses API urls and master key from existing configuration
 
 DESCRIPTION
   Initialize the CLI to communicate with Conduit

--- a/src/commands/generateClient/rest.ts
+++ b/src/commands/generateClient/rest.ts
@@ -58,7 +58,7 @@ export class GenerateClientRest extends Command {
 
   private async convertToZip(libPath: string) {
     const zipPath = `${libPath}.zip`;
-    execSync(`zip -r ${zipPath} ${libPath}`);
+    execSync(`zip -rj ${zipPath} ${libPath}`);
     fs.rm(libPath, { recursive: true, force: true }, err => {
       if (err) {
         console.error(err);

--- a/src/http/http.ts
+++ b/src/http/http.ts
@@ -1,88 +1,124 @@
-import { Command } from '@oclif/core';
+import { Command, CliUx } from '@oclif/core';
 import axios, { AxiosResponse } from 'axios';
-import { storeSecurityClientConfiguration, recoverSecurityClientConfig } from '../utils/requestUtils';
+import {
+  storeSecurityClientConfiguration,
+  recoverSecurityClientConfig,
+} from '../utils/requestUtils';
+import { booleanPrompt } from '../utils/cli';
 import { IGetSecurityClients } from '../interfaces';
 import * as os from 'os';
 
 export class Requests {
   private readonly command: Command;
-  private readonly URL: string;
-  private readonly baseHeaders: {
-    masterkey: string;
-  };
+  private readonly adminUrl: string;
+  private readonly appUrl?: string;
+  private baseHeaders: {
+    [header: string]: string;
+  } = {};
   private token?: string;
   private clientValidation: {
-    enabled: boolean,
-    clientId?: string,
-    clientSecret?: string,
+    enabled: boolean;
+    clientId?: string;
+    clientSecret?: string;
   } = { enabled: false };
 
-  constructor(command: Command, url: string, masterKey: string) {
+  constructor(command: Command, adminUrl: string, appUrl?: string) {
     this.command = command;
-    this.URL = url;
-    this.baseHeaders = {
-      masterkey: masterKey,
-    };
-    // Interceptors
-    const self = this;
-    axios.interceptors.request.use(
-      (config) => {
-        config.headers = self.getRequestHeaders();
-        return config;
-      },
-      (error) => {
-        console.log(error);
-        return Promise.reject(error.response);
-      }
-    );
+    this.adminUrl = adminUrl;
+    this.appUrl = appUrl;
   }
 
-  async initialize(username: string, password: string) {
+  async initialize(
+    username: string,
+    password: string,
+    masterKey: string,
+    usesRouter: boolean,
+  ) {
+    this.baseHeaders['masterkey'] = masterKey;
+    axios.interceptors.request.use(
+      config => {
+        config.headers = this.getRequestHeaders();
+        return config;
+      },
+      error => {
+        return Promise.reject(error.response);
+      },
+    );
     this.token = await this.loginRequest(username, password);
-    const securityConfig = await this.getModuleConfig('security')
-      .catch(() => {
-        console.log('Failed to retrieve Conduit Security configuration');
+    if (usesRouter) {
+      const routerConfig = await this.getModuleConfig('router').catch(async () => {
+        CliUx.ux.log('Please make sure Conduit Router is online before proceeding.');
         process.exit(-1);
       });
-    if (securityConfig.clientValidation.enabled) {
-      this.clientValidation.enabled = true;
-      let securityClient = await recoverSecurityClientConfig(this.command)
-        .catch(() => { return { clientId: '', clientSecret: '' } });
-      if (!await this.validSecurityClient(securityClient.clientId)) {
-        securityClient = await this.createSecurityClient();
+      if (routerConfig.security.clientValidation.enabled) {
+        this.clientValidation.enabled = true;
+        let securityClient = await recoverSecurityClientConfig(this.command).catch(() => {
+          return { clientId: '', clientSecret: '' };
+        });
+        if (!(await this.validSecurityClient(securityClient.clientId))) {
+          securityClient = await this.createSecurityClient();
+        }
+        this.clientValidation.clientId = securityClient.clientId;
+        this.clientValidation.clientSecret = securityClient.clientSecret;
       }
-      this.clientValidation.clientId = securityClient.clientId;
-      this.clientValidation.clientSecret = securityClient.clientSecret;
     }
   }
 
   private getRequestHeaders() {
     return {
       ...this.baseHeaders,
-      ...(this.token && { Authorization: `JWT ${this.token}` }),
+      ...(this.token && { Authorization: `Bearer ${this.token}` }),
     };
   }
 
   get securityClient() {
     return this.clientValidation.enabled
-      ? { clientId: this.clientValidation.clientId!, clientSecret: this.clientValidation.clientSecret! }
+      ? {
+          clientId: this.clientValidation.clientId!,
+          clientSecret: this.clientValidation.clientSecret!,
+        }
       : null;
   }
 
   // API Requests
-  async httpHealthCheck() {
-    return axios.get(`${this.URL}/health`)
-      .then(() => true)
-      .catch(() => false);
+  async httpHealthCheck(api: 'admin' | 'app') {
+    // NOTE: This won't work for: v0.14.0, v0.14.1, v0.14.2, v0.14.3, v0.14.4
+    if (api === 'app' && !this.appUrl) {
+      CliUx.ux.error('No Application API url specified. Health check failed.', {
+        exit: -1,
+      });
+    }
+    let pingRoutes: string[];
+    if (api === 'admin') {
+      pingRoutes = [`${this.adminUrl}/ready`];
+    } else {
+      pingRoutes = [
+        `${this.appUrl}/ready`,
+        `${this.appUrl}/health`, // fallback: <=v0.14.4
+      ];
+    }
+    for (const route of pingRoutes) {
+      const success = await axios
+        .get(route)
+        .then(res => {
+          return (
+            res.data.result ===
+            (api === 'app' ? 'Conduit is online!' : 'Conduit Core is online!')
+          );
+        })
+        .catch(() => false);
+      if (success) return true;
+    }
+    return false;
   }
 
   loginRequest(username: string, password: string): Promise<string> {
     return axios
-      .post(`${this.URL}/admin/login`, {
+      .post(`${this.adminUrl}/login`, {
         username,
         password,
       })
-      .then((r: AxiosResponse<{token: string}>) => {
+      .then((r: AxiosResponse<{ token: string }>) => {
         this.token = r.data.token;
         return this.token;
       });
@@ -90,23 +126,25 @@ export class Requests {
 
   getSchemasRequest(skip: number, limit: number) {
     return axios
-      .get(`${this.URL}/admin/database/schemas`, { params: { skip, limit } })
-      .then((r) => r.data);
+      .get(`${this.adminUrl}/database/schemas`, { params: { skip, limit } })
+      .then(r => r.data);
   }
 
-  getAdminModulesRequest() {
-    return axios.get(`${this.URL}/admin/config/modules`).then(r => r.data);
+  getModulesRequest() {
+    return axios.get(`${this.adminUrl}/config/modules`).then(r => r.data);
   }
 
   getModuleConfig(module: string) {
-    return axios.get(`${this.URL}/admin/config/${module}`).then(r => r.data.config);
+    return axios.get(`${this.adminUrl}/config/${module}`).then(r => r.data.config);
   }
 
   fetchSecurityClients() {
     if (!this.clientValidation.enabled) {
       throw new Error('Security Clients are disabled');
     }
-    return axios.get(`${this.URL}/admin/security/client`).then((r: IGetSecurityClients) => r.data.clients);
+    return axios
+      .get(`${this.adminUrl}/router/security/client`)
+      .then((r: IGetSecurityClients) => r.data.clients);
   }
 
   async createSecurityClient() {
@@ -114,15 +152,18 @@ export class Requests {
       throw new Error('Security Clients are disabled');
     }
     const hostname = os.hostname;
-    const uniqueSuffix = (Math.floor(Math.random() * Number.MAX_SAFE_INTEGER).toString(36)).substring(0, 6);
-    const securityClient = await axios.post(
-      `${this.URL}/admin/security/client`,
-      {
+    const uniqueSuffix = Math.floor(Math.random() * Number.MAX_SAFE_INTEGER)
+      .toString(36)
+      .substring(0, 6);
+    const securityClient = await axios
+      .post(`${this.adminUrl}/router/security/client`, {
         platform: 'CLI',
         alias: `cli-${hostname}_${uniqueSuffix}`,
         notes: `A Conduit CLI Client for ${hostname}`,
-      },
-    ).then(r => { return { clientId: r.data.clientId, clientSecret: r.data.clientSecret } })
+      })
+      .then(r => {
+        return { clientId: r.data.clientId, clientSecret: r.data.clientSecret };
+      });
     await storeSecurityClientConfiguration(this.command, securityClient);
     return securityClient;
   }

--- a/src/http/http.ts
+++ b/src/http/http.ts
@@ -4,7 +4,6 @@ import {
   storeSecurityClientConfiguration,
   recoverSecurityClientConfig,
 } from '../utils/requestUtils';
-import { booleanPrompt } from '../utils/cli';
 import { IGetSecurityClients } from '../interfaces';
 import * as os from 'os';
 

--- a/src/utils/generateClient.ts
+++ b/src/utils/generateClient.ts
@@ -47,8 +47,8 @@ export async function getOutputPath(
   return outputPath;
 }
 
-export async function getBaseUrl(command: Command) {
-  const { url } = await recoverApiConfig(command).catch(async () => {
+export async function recoverApiConfigSafe(command: Command) {
+  return await recoverApiConfig(command).catch(async () => {
     const runInit = await booleanPrompt(
       'No configuration found. Run init and proceed?',
       'yes',
@@ -61,7 +61,6 @@ export async function getBaseUrl(command: Command) {
     await init.run();
     return await recoverApiConfig(command);
   });
-  return url;
 }
 
 function validateDirectoryPath(path: string) {


### PR DESCRIPTION
This PR fixes certain API request formats that were broken in v0.14.x.
It also introduces support for generating admin client libraries for GrahphQL.
Fixes REST client lib zip files including a redundant nested directory structure.

Due to `v0.14.0` - `v0.14.4` missing an administrative health check endpoint, running `init` now requires `v0.14.5`.
Commands depending on `init` should (mostly) function with older versions, but the active deployment config files are going to have to be edited manually.

The `deploy` command can still bring up any target tag requested, but I don't think we should focus too much on making the rest of the `cli` backwards-compatible as that is going to overcomplicate the codebase and won't be easy to maintain going forward due to changes in headers, api urls, request base paths, changed uris, security headers and more.
