### PR TITLE
feat(deploy): v0.15

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ USAGE
 * [`conduit deploy setup`](#conduit-deploy-setup)
 * [`conduit deploy start`](#conduit-deploy-start)
 * [`conduit deploy stop`](#conduit-deploy-stop)
+* [`conduit deploy update`](#conduit-deploy-update)
 * [`conduit generateClient graphql`](#conduit-generateclient-graphql)
 * [`conduit generateClient rest`](#conduit-generateclient-rest)
 * [`conduit generateSchema [PATH]`](#conduit-generateschema-path)
@@ -53,17 +54,18 @@ USAGE
 
 ## `conduit deploy rm`
 
-Bring down a local Conduit deployment
+Remove your local Conduit deployment
 
 ```
 USAGE
-  $ conduit deploy rm [-t <value>]
+  $ conduit deploy rm [--wipe-data] [--defaults]
 
 FLAGS
-  -t, --target=<value>  Specify target deployment
+  --defaults   Select default values
+  --wipe-data  Wipe data volumes
 
 DESCRIPTION
-  Bring down a local Conduit deployment
+  Remove your local Conduit deployment
 ```
 
 ## `conduit deploy setup`
@@ -72,10 +74,11 @@ Bootstrap a local Conduit deployment
 
 ```
 USAGE
-  $ conduit deploy setup [--config]
+  $ conduit deploy setup [--config] [--target <value>]
 
 FLAGS
-  --config  Enable manual deployment configuration
+  --config          Enable manual deployment configuration
+  --target=<value>  Specify target tag
 
 DESCRIPTION
   Bootstrap a local Conduit deployment
@@ -83,32 +86,42 @@ DESCRIPTION
 
 ## `conduit deploy start`
 
-Bring up a local Conduit deployment
+Bring up your local Conduit deployment
 
 ```
 USAGE
-  $ conduit deploy start [-t <value>]
-
-FLAGS
-  -t, --target=<value>  Specify target deployment
+  $ conduit deploy start
 
 DESCRIPTION
-  Bring up a local Conduit deployment
+  Bring up your local Conduit deployment
 ```
 
 ## `conduit deploy stop`
 
-Bring down a local Conduit deployment
+Bring down your local Conduit deployment
 
 ```
 USAGE
-  $ conduit deploy stop [-t <value>]
-
-FLAGS
-  -t, --target=<value>  Specify target deployment
+  $ conduit deploy stop
 
 DESCRIPTION
-  Bring down a local Conduit deployment
+  Bring down your local Conduit deployment
+```
+
+## `conduit deploy update`
+
+Update your local Conduit deployment
+
+```
+USAGE
+  $ conduit deploy update [--config] [--target <value>]
+
+FLAGS
+  --config          Enable manual deployment configuration
+  --target=<value>  Specify target tag
+
+DESCRIPTION
+  Update your local Conduit deployment
 ```
 
 ## `conduit generateClient graphql`

--- a/src/commands/deploy/setup.ts
+++ b/src/commands/deploy/setup.ts
@@ -1,11 +1,18 @@
-import { Command, Flags, CliUx } from '@oclif/core';
+import { CliUx, Command, Flags } from '@oclif/core';
 import { DeployStart } from './start';
-import { DeploymentConfiguration } from '../../deploy/types';
-import { booleanPrompt, promptWithOptions } from '../../utils/cli';
-import axios from 'axios';
-import * as path from 'path';
-import * as fs from 'fs-extra';
-import * as yaml from 'js-yaml';
+import { DeployUpdate } from './update';
+import {
+  abortAsFriends,
+  assertValidConduitTag,
+  compareTags,
+  deploymentIsRunning,
+  getActiveDeploymentTagOrUndefined,
+  getAvailableTags,
+  selectConduitTag,
+} from '../../deploy/utils';
+import { Setup } from '../../deploy/Setup';
+import { TagComparison } from '../../deploy/types';
+import { booleanPrompt } from '../../utils/cli';
 
 export class DeploySetup extends Command {
   static description = 'Bootstrap a local Conduit deployment';
@@ -13,189 +20,69 @@ export class DeploySetup extends Command {
     config: Flags.boolean({
       description: 'Enable manual deployment configuration',
     }),
+    target: Flags.string({
+      description: 'Specify target tag',
+    }),
   };
 
-  private readonly manifestBasePath = path.join(
-    this.config.cacheDir,
-    'deploy',
-    'manifests',
-  );
-  private readonly deployConfigBasePath = path.join(this.config.configDir, 'deploy');
   private userConfiguration!: boolean;
-  private conduitTags: string[] = [];
-  private conduitUiTags: string[] = [];
-  private selectedTag!: string;
-  private deploymentConfig: DeploymentConfiguration = {
-    modules: [],
-    environment: {},
-  };
-  private supportedModules: string[] = [];
+  private targetTag?: string;
+  private conduitTags!: string[];
 
   async run() {
-    // Get Conduit Releases
-    await this.getTags('Conduit');
-    await this.getTags('Conduit-UI');
-    this.userConfiguration = (await this.parse(DeploySetup)).flags.config;
-    // Select Target Release
-    if (!this.userConfiguration) {
-      this.selectedTag = this.conduitTags[0];
-    } else {
-      while (!this.conduitTags.includes(this.selectedTag)) {
-        this.selectedTag = await CliUx.ux.prompt('Specify your desired Conduit version', {
-          default: this.conduitTags[0],
-        });
-        if (!this.conduitTags.includes(this.selectedTag)) {
-          CliUx.ux.log(
-            `Please choose a valid target tag. Example: ${this.conduitTags[0]}\n`,
-          );
-        }
-      }
+    const flags = (await this.parse(DeployUpdate)).flags;
+    this.userConfiguration = flags.config ?? false;
+    this.targetTag = flags.target;
+    // Get Available Conduit Releases
+    this.conduitTags = await getAvailableTags('Conduit');
+    if (this.targetTag) {
+      assertValidConduitTag(this.conduitTags, this.targetTag);
     }
-    // Pull Compose Files
-    await this.pullComposeFiles();
-    // Select Modules
-    if (!this.userConfiguration) {
-      this.deploymentConfig.modules.push('mongodb');
+    // Check Deployment Status
+    const activeTag = getActiveDeploymentTagOrUndefined(this);
+    if (activeTag) {
+      await this.handleExistingDeployment(activeTag);
     } else {
-      await this.indexSupportedModules();
-      await this.selectModules();
-    }
-    // Configure Environment
-    await this.configureEnvironment();
-    // Store User Configuration
-    await this.storeDeploymentConfig();
-    // Start Deployment
-    await DeployStart.run(['--target', this.selectedTag]);
-  }
-
-  private async pullComposeFiles() {
-    let manifestUrl: string, envUrl: string;
-    const cacheDir = path.join(
-      this.config.cacheDir,
-      'deploy',
-      'manifests',
-      this.selectedTag,
-    );
-    const tagPrefix = this.selectedTag.slice(1).split('.').slice(0, 2).join('.');
-    if (this.conduitTags[0].startsWith(`v${tagPrefix}`)) {
-      manifestUrl =
-        'https://raw.githubusercontent.com/ConduitPlatform/Conduit/main/docker/docker-compose.yml';
-      envUrl =
-        'https://raw.githubusercontent.com/ConduitPlatform/Conduit/main/docker/.env';
-    } else if (!isNaN(parseFloat(tagPrefix)) && parseFloat(tagPrefix) < 0.15) {
-      const targetBranch = `v${tagPrefix}.x`;
-      manifestUrl = `https://raw.githubusercontent.com/ConduitPlatform/Conduit/${targetBranch}/docker/docker-compose.yml`;
-      envUrl = `https://raw.githubusercontent.com/ConduitPlatform/Conduit/${targetBranch}/docker/.env`;
-    } else {
-      // (number && >= 0.15) or !number
-      manifestUrl = `https://github.com/ConduitPlatform/Conduit/blob/${this.selectedTag}/docker/docker-compose.yml`;
-      envUrl = `https://github.com/ConduitPlatform/Conduit/blob/${this.selectedTag}/docker/.env`;
-    }
-    await fs.ensureDir(cacheDir);
-    await axios
-      .get(manifestUrl, { responseType: 'stream' })
-      .then(async response => {
-        const filePath = path.join(cacheDir, 'compose.yml');
-        await fs.ensureFile(filePath);
-        response.data.pipe(fs.createWriteStream(filePath));
-      })
-      .catch(() => CliUx.ux.error('Failed to download compose file', { exit: -1 }));
-    await axios
-      .get(envUrl, { responseType: 'stream' })
-      .then(async response => {
-        const filePath = path.join(cacheDir, 'env');
-        await fs.ensureFile(filePath);
-        response.data.pipe(fs.createWriteStream(filePath));
-      })
-      .catch(() => CliUx.ux.error('Failed to download env file', { exit: -1 }));
-  }
-
-  private async getTags(repo: 'Conduit' | 'Conduit-UI') {
-    const res = await axios.get(
-      `https://api.github.com/repos/ConduitPlatform/${repo}/releases`,
-      { headers: { Accept: 'application/vnd.github.v3+json' } },
-    );
-    const releases: string[] = [];
-    const rcReleases: string[] = [];
-    res.data.forEach((release: any) => {
-      if (release.tag_name.indexOf('-') === -1) {
-        releases.push(release.tag_name);
-      } else {
-        rcReleases.push(release.tag_name);
-      }
-    });
-    releases.sort().reverse();
-    rcReleases.sort().reverse();
-    releases.push(...rcReleases);
-    if (repo === 'Conduit') {
-      this.conduitTags = releases;
-    } else {
-      this.conduitUiTags = releases;
-    }
-  }
-
-  private async indexSupportedModules() {
-    // TODO: Parse and store dependencies too
-    let modules: string[] = [];
-    const composeFile = yaml.load(
-      fs.readFileSync(
-        path.join(this.manifestBasePath, this.selectedTag, 'compose.yml'),
-        'utf-8',
-      ),
-    ) as { services: { [key: string]: { profiles?: string[] } } };
-    Object.entries(composeFile.services).forEach(([_, serviceDefinition]) => {
-      if (serviceDefinition.profiles) {
-        modules = modules.concat(serviceDefinition.profiles);
-      }
-    });
-    this.supportedModules = modules;
-  }
-
-  private async selectModules() {
-    if (!this.supportedModules.includes('postgres')) {
-      this.deploymentConfig.modules.push('mongodb');
-    } else {
-      this.deploymentConfig.modules.push(
-        await promptWithOptions(
-          `Select database engine type`,
-          ['mongodb', 'postgres'],
-          'mongodb',
-          false,
-        ),
+      const conduitTag = await selectConduitTag(
+        this.conduitTags,
+        this.userConfiguration,
+        this.targetTag,
       );
-    }
-    for (const pkg of this.supportedModules) {
-      if (pkg === 'mongodb' || pkg === 'postgres') continue;
-      const enable = await booleanPrompt(`Bring up ${pkg}?`, 'no');
-      if (enable) this.deploymentConfig.modules.push(pkg);
+      const setup = new Setup(this, this.userConfiguration, conduitTag);
+      await setup.setupEnvironment();
+      await DeployStart.run();
     }
   }
 
-  private async configureEnvironment() {
-    // If selected tag's major is the latest major, explicitly specify target Conduit tag and latest Conduit-UI.
-    // This is a workaround for outdated env files in the main branch.
-    const tagPrefix = this.selectedTag.slice(1).split('.').slice(0, 2).join('.');
-    if (this.conduitTags[0].startsWith(`v${tagPrefix}`)) {
-      this.deploymentConfig.environment = {
-        IMAGE_TAG: this.selectedTag,
-        UI_IMAGE_TAG: this.conduitUiTags[0],
-      };
+  private async handleExistingDeployment(activeTag: string) {
+    CliUx.ux.log(`You already have a deployed Conduit (${activeTag}) environment.`);
+    const latestStable = await selectConduitTag(this.conduitTags, false);
+    const tagComparison = compareTags(activeTag, latestStable);
+    if (tagComparison === TagComparison.SecondIsNewer) {
+      // Update Available
+      CliUx.ux.log(
+        'Our dedicated team of highly trained marsupials ' +
+          `has detected an available update (${latestStable}).`,
+      );
+      const update = await booleanPrompt('Do you wish to upgrade your deployment?');
+      if (!update) abortAsFriends();
+      const updateArgs = [
+        ...(this.userConfiguration ? ['--config'] : []),
+        ...(this.targetTag ? ['--target', this.targetTag] : []),
+      ];
+      await DeployUpdate.run(updateArgs);
+    } else {
+      // No Update Available
+      let start: boolean;
+      if (await deploymentIsRunning(this)) {
+        start = await booleanPrompt(
+          'Do you wish to restart your already running deployment?',
+        );
+      } else {
+        start = await booleanPrompt('Do you wish to start your deployment?');
+      }
+      if (!start) abortAsFriends();
+      await DeployStart.run();
     }
-    // TODO: Parse .env file and prompt for overrides
-    if (this.deploymentConfig.modules.includes('postgres')) {
-      this.deploymentConfig.environment.DB_CONN_URI =
-        'postgres://conduit:pass@conduit-postgres:5432/conduit';
-      this.deploymentConfig.environment.DB_TYPE = this.selectedTag.startsWith('v0.11')
-        ? 'sql'
-        : 'postgres';
-      this.deploymentConfig.environment.DB_PORT = '5432';
-    }
-  }
-
-  private async storeDeploymentConfig() {
-    const deployConfigPath = path.join(this.deployConfigBasePath, this.selectedTag);
-    await fs.ensureDir(this.deployConfigBasePath);
-    await fs.ensureFile(deployConfigPath);
-    fs.writeJsonSync(deployConfigPath, this.deploymentConfig);
   }
 }

--- a/src/commands/deploy/start.ts
+++ b/src/commands/deploy/start.ts
@@ -1,44 +1,28 @@
-import { Command, Flags, CliUx } from '@oclif/core';
+import { Command, CliUx } from '@oclif/core';
 import dockerCompose from '../../docker/dockerCompose';
 import { DeploymentConfiguration } from '../../deploy/types';
-import { listLocalDeployments, getDeploymentPaths } from '../../deploy/utils';
+import { getTargetDeploymentPaths } from '../../deploy/utils';
 import * as fs from 'fs-extra';
 import * as dotenv from 'dotenv';
 import * as open from 'open';
 
 export class DeployStart extends Command {
-  static description = 'Bring up a local Conduit deployment';
-  static flags = {
-    target: Flags.string({
-      char: 't',
-      description: 'Specify target deployment',
-    }),
-  };
+  static description = 'Bring up your local Conduit deployment';
 
   private deploymentConfig!: DeploymentConfiguration;
 
   async run() {
-    // Select Target Deployment
-    let target = (await this.parse(DeployStart)).flags.target;
-    if (!target) {
-      const availableDeployments = await listLocalDeployments(this);
-      CliUx.ux.log('Available Deployment Targets:');
-      availableDeployments.forEach(target => CliUx.ux.log(`- ${target}`));
-      do {
-        target = (await CliUx.ux.prompt('Select a target')) as string;
-      } while (!availableDeployments.includes(target));
-    }
     // Retrieve Compose Files
     const {
       manifestPath: cwd,
       envPath,
-      deploymentPath,
-    } = getDeploymentPaths(this, target);
+      deploymentConfigPath,
+    } = getTargetDeploymentPaths(this, true);
     const processEnv = JSON.parse(JSON.stringify(process.env));
     process.env = {};
     dotenv.config({ path: envPath });
     // Retrieve User Configuration
-    this.deploymentConfig = await fs.readJSONSync(deploymentPath);
+    this.deploymentConfig = await fs.readJSONSync(deploymentConfigPath);
     const composeOptions = this.deploymentConfig.modules.map(m => ['--profile', m]);
     const env = {
       ...JSON.parse(JSON.stringify(process.env)),

--- a/src/commands/deploy/update.ts
+++ b/src/commands/deploy/update.ts
@@ -1,0 +1,76 @@
+import { Command, CliUx, Flags } from '@oclif/core';
+import { TagComparison } from '../../deploy/types';
+import {
+  compareTags,
+  abortAsEnemies,
+  getActiveDeploymentTag,
+  getAvailableTags,
+  selectConduitTag,
+} from '../../deploy/utils';
+import { booleanPrompt } from '../../utils/cli';
+import { DeployRemove } from './rm';
+import { DeployStart } from './start';
+import { Setup } from '../../deploy/Setup';
+
+export class DeployUpdate extends Command {
+  static description = 'Update your local Conduit deployment';
+  static flags = {
+    config: Flags.boolean({
+      description: 'Enable manual deployment configuration',
+    }),
+    target: Flags.string({
+      description: 'Specify target tag',
+    }),
+  };
+
+  private conduitTag!: string;
+  private wipeData: boolean = false;
+
+  async run() {
+    const flags = (await this.parse(DeployUpdate)).flags;
+    const userConfiguration = flags.config ?? false;
+    const targetTag = flags.target;
+    // Retrieve Target Deployment
+    const activeTag = getActiveDeploymentTag(this);
+    // Get Available Conduit Releases
+    const conduitTags = await getAvailableTags('Conduit');
+    // Get Target Tag
+    this.conduitTag = await selectConduitTag(conduitTags, userConfiguration, targetTag);
+    if (activeTag === this.conduitTag) {
+      CliUx.ux.log('No updates available... 👍');
+      CliUx.ux.exit(0);
+    }
+    CliUx.ux.log(`Deployed Release:\t${activeTag}`);
+    CliUx.ux.log(`Target Release:  \t${this.conduitTag}`);
+    // Compare Tags
+    const tagComparison = compareTags(activeTag, this.conduitTag);
+    if (tagComparison === TagComparison.FirstIsNewer) {
+      // Current tag is more recent => Redeploy, Wipe Data
+      CliUx.ux.log(
+        `You are about to downgrade your deployment from '${activeTag}' to '${this.conduitTag}' 🤔`,
+      );
+      CliUx.ux.log('Continuing will replace existing deployment, wiping your data 🗑️');
+      this.wipeData = true;
+    } else if (tagComparison === TagComparison.SecondIsNewer) {
+      // Current tag is older => Update, Persist Data
+      CliUx.ux.log('Continuing will update existing deployment, preserving your data ✅');
+    } else if (tagComparison === TagComparison.Equal) {
+      // Same tag => Redeploy, Persist Data
+      CliUx.ux.log(
+        'Continuing will replace existing deployment, preserving your data ✅',
+      );
+    }
+    const accept = await booleanPrompt('Continue?', 'no');
+    if (!accept) {
+      abortAsEnemies();
+    }
+    // Remove Existing Deployment
+    const removeArgs = [...(this.wipeData ? ['--wipe-data'] : []), '--defaults'];
+    await DeployRemove.run(removeArgs);
+    // Setup New Deployment
+    const setup = new Setup(this, userConfiguration, this.conduitTag);
+    await setup.setupEnvironment();
+    // Run New Deployment
+    await DeployStart.run();
+  }
+}

--- a/src/deploy/Setup.ts
+++ b/src/deploy/Setup.ts
@@ -1,0 +1,130 @@
+import { DeploymentConfiguration } from './types';
+import { booleanPrompt, promptWithOptions } from '../utils/cli';
+import {
+  getBaseDeploymentPaths,
+  getAvailableTags,
+  setActiveDeploymentTag,
+  getMatchingUiTag,
+} from './utils';
+import { CliUx, Command } from '@oclif/core';
+import axios from 'axios';
+import * as path from 'path';
+import * as fs from 'fs-extra';
+import * as yaml from 'js-yaml';
+
+export class Setup {
+  private readonly manifestBasePath: string;
+  private readonly deployConfigBasePath: string;
+  private supportedModules: string[] = [];
+  private deploymentConfig: DeploymentConfiguration = {
+    modules: [],
+    environment: {},
+  };
+
+  constructor(
+    private readonly command: Command,
+    private readonly userConfiguration: boolean,
+    private readonly selectedTag: string,
+  ) {
+    this.manifestBasePath = getBaseDeploymentPaths(command).manifestBasePath;
+    this.deployConfigBasePath = getBaseDeploymentPaths(command).configBasePath;
+  }
+
+  async setupEnvironment() {
+    // Pull Compose Files
+    await this.pullComposeFiles();
+    // Select Modules
+    if (!this.userConfiguration) {
+      this.deploymentConfig.modules.push('mongodb');
+    } else {
+      await this.indexSupportedModules();
+      await this.selectModules();
+    }
+    // Configure Environment
+    await this.configureEnvironment();
+    // Store User Configuration
+    await this.storeDeploymentConfig();
+  }
+
+  private async indexSupportedModules() {
+    // TODO: Parse and store dependencies too
+    let modules: string[] = [];
+    const composeFile = yaml.load(
+      fs.readFileSync(
+        path.join(this.manifestBasePath, this.selectedTag, 'compose.yml'),
+        'utf-8',
+      ),
+    ) as { services: { [key: string]: { profiles?: string[] } } };
+    Object.entries(composeFile.services).forEach(([_, serviceDefinition]) => {
+      if (serviceDefinition.profiles) {
+        modules = modules.concat(serviceDefinition.profiles);
+      }
+    });
+    this.supportedModules = modules;
+  }
+
+  private async selectModules() {
+    this.deploymentConfig.modules.push(
+      await promptWithOptions(
+        `Select database engine type`,
+        ['mongodb', 'postgres'],
+        'mongodb',
+        false,
+      ),
+    );
+    for (const pkg of this.supportedModules) {
+      if (pkg === 'mongodb' || pkg === 'postgres') continue;
+      const enable = await booleanPrompt(`Bring up ${pkg}?`, 'no');
+      if (enable) this.deploymentConfig.modules.push(pkg);
+    }
+  }
+
+  private async configureEnvironment() {
+    const uiTags = await getAvailableTags('Conduit-UI');
+    const selectedUiTag = await getMatchingUiTag(this.selectedTag, uiTags);
+    this.deploymentConfig.environment = {
+      IMAGE_TAG: this.selectedTag,
+      UI_IMAGE_TAG: selectedUiTag,
+    };
+    // TODO: Parse .env file and prompt for overrides
+    if (this.deploymentConfig.modules.includes('postgres')) {
+      this.deploymentConfig.environment.DB_CONN_URI =
+        'postgres://conduit:pass@conduit-postgres:5432/conduit';
+      this.deploymentConfig.environment.DB_TYPE = 'postgres';
+      this.deploymentConfig.environment.DB_PORT = '5432';
+    }
+  }
+
+  private async storeDeploymentConfig() {
+    const deployConfigPath = path.join(this.deployConfigBasePath, this.selectedTag);
+    await fs.ensureDir(this.deployConfigBasePath);
+    await fs.ensureFile(deployConfigPath);
+    fs.writeJsonSync(deployConfigPath, this.deploymentConfig);
+    setActiveDeploymentTag(this.command, this.selectedTag);
+  }
+
+  private async pullComposeFiles() {
+    await this.pullFile('docker/docker-compose.yml', 'compose', 'compose.yml');
+    await this.pullFile('docker/.env', 'env', 'env');
+    await this.pullFile(
+      'docker/prometheus.cfg.yml',
+      'prometheus configuration',
+      'prometheus.cfg.yml',
+    );
+    await this.pullFile('docker/loki.cfg.yml', 'loki configuration', 'loki.cfg.yml');
+  }
+
+  private async pullFile(gitPath: string, humanName: string, dstFileName: string) {
+    const cacheDir = path.join(this.manifestBasePath, this.selectedTag);
+    await fs.ensureDir(cacheDir);
+    const url = `https://raw.githubusercontent.com/ConduitPlatform/Conduit/${this.selectedTag}/${gitPath}`;
+    await axios
+      .get(url, { responseType: 'stream' })
+      .then(async response => {
+        const filePath = path.join(cacheDir, dstFileName);
+        await fs.ensureFile(filePath);
+        response.data.pipe(fs.createWriteStream(filePath));
+      })
+      .catch(() => CliUx.ux.error(`Failed to download ${humanName} file`, { exit: -1 }));
+  }
+}

--- a/src/deploy/types.ts
+++ b/src/deploy/types.ts
@@ -2,3 +2,9 @@ export interface DeploymentConfiguration {
   modules: string[];
   environment: { [key: string]: string };
 }
+
+export enum TagComparison {
+  FirstIsNewer,
+  SecondIsNewer,
+  Equal,
+}

--- a/src/deploy/utils.ts
+++ b/src/deploy/utils.ts
@@ -1,41 +1,221 @@
-import { Command, CliUx } from '@oclif/core';
+import { CliUx, Command } from '@oclif/core';
 import { Docker } from '../docker';
+import { TagComparison } from './types';
 import * as path from 'path';
 import * as fs from 'fs-extra';
+import axios from 'axios';
 
-export async function listLocalDeployments(command: Command, running = false) {
-  const deploymentBasePath = path.join(command.config.configDir, 'deploy');
-  const deployments = fs.readdirSync(deploymentBasePath).filter(file => {
-    return fs.statSync(path.join(deploymentBasePath, file)).isFile();
-  });
-  let onlineDeployments: string[];
-  if (running) {
-    onlineDeployments = [];
-    for (const deployment of deployments) {
-      if (await Docker.getInstance().containerIsUp(`conduit-${deployment}`)) {
-        onlineDeployments.push(deployment);
-      }
-    }
-  } else {
-    onlineDeployments = deployments;
-  }
-  return onlineDeployments;
+export function getBaseDeploymentPaths(command: Command) {
+  const configBasePath = path.join(command.config.configDir, 'deploy');
+  const manifestBasePath = path.join(command.config.cacheDir, 'deploy', 'manifests');
+  return { configBasePath, manifestBasePath };
 }
 
-export function getDeploymentPaths(command: Command, tag: string) {
-  const manifestPath = path.join(command.config.cacheDir, 'deploy', 'manifests', tag);
-  const deploymentPath = path.join(command.config.configDir, 'deploy', tag);
+export function getTargetDeploymentPaths(command: Command, chatty = false) {
+  const tag = getActiveDeploymentTag(command);
+  const { configBasePath, manifestBasePath } = getBaseDeploymentPaths(command);
+  const deploymentConfigPath = path.join(configBasePath, tag!);
+  const manifestPath = path.join(manifestBasePath, tag!);
   const composePath = path.join(manifestPath, 'compose.yml');
   const envPath = path.join(manifestPath, 'env');
   if (
-    !fs.existsSync(manifestPath) ||
-    !fs.existsSync(deploymentPath) ||
+    !fs.existsSync(deploymentConfigPath) ||
+    !fs.existsSync(composePath) ||
     !fs.existsSync(envPath)
   ) {
     CliUx.ux.error(
-      `Target deployment "${tag}" does not exist. Did you run deploy setup?`,
+      chatty
+        ? 'Deployment files could not be retrieved. Did you run deploy setup?'
+        : 'No deployment available',
     );
     CliUx.ux.exit(-1);
   }
-  return { manifestPath, deploymentPath, composePath, envPath };
+  return { deploymentConfigPath, manifestPath, composePath, envPath };
+}
+
+export function setActiveDeploymentTag(command: Command, tag: string) {
+  const { configBasePath } = getBaseDeploymentPaths(command);
+  fs.writeFileSync(path.join(configBasePath, 'active'), tag);
+}
+
+function _getActiveDeploymentTag(command: Command, throwOnNull = true) {
+  const { configBasePath } = getBaseDeploymentPaths(command);
+  let activeTag: string | undefined = undefined;
+  try {
+    activeTag = fs
+      .readFileSync(path.join(configBasePath, 'active'), {
+        encoding: 'utf-8',
+        flag: 'r',
+      })
+      .trim();
+    activeTag = activeTag !== '' ? activeTag : undefined;
+  } catch {}
+  return activeTag;
+}
+
+export function getActiveDeploymentTag(command: Command) {
+  const activeTag = _getActiveDeploymentTag(command);
+  if (!activeTag) {
+    CliUx.ux.log('No deployment available 😵');
+    CliUx.ux.exit(0);
+  }
+  return activeTag;
+}
+
+export function getActiveDeploymentTagOrUndefined(command: Command) {
+  return _getActiveDeploymentTag(command);
+}
+
+export function unsetActiveDeployment(command: Command) {
+  const { configBasePath } = getBaseDeploymentPaths(command);
+  try {
+    fs.unlinkSync(path.join(configBasePath, 'active'));
+  } catch {}
+}
+
+export async function deploymentIsRunning(command: Command) {
+  const tag = getActiveDeploymentTagOrUndefined(command);
+  if (!tag) return false;
+  if (await Docker.getInstance().containerIsUp(`conduit-${tag}`)) {
+    return true;
+  }
+}
+
+export function compareTags(tagA: string, tagB: string, depth = 0): TagComparison {
+  // ex format: 'v0.15.1-rc1'
+  const baseVersionA = parseFloat(depth === 0 ? tagA.slice(1) : tagA);
+  const baseVersionB = parseFloat(depth === 0 ? tagB.slice(1) : tagB);
+  if (tagA === tagB) {
+    return TagComparison.Equal;
+  } else if (baseVersionA > baseVersionB) {
+    return TagComparison.FirstIsNewer;
+  } else if (baseVersionA < baseVersionB) {
+    return TagComparison.SecondIsNewer;
+  } else {
+    if (depth < 2) {
+      return compareTags(
+        tagA.slice(tagA.indexOf('.') + 1),
+        tagB.slice(tagB.indexOf('.') + 1),
+        depth + 1,
+      );
+    } else {
+      // release candidate
+      if (!tagA.includes('-') && tagB.includes('-')) return TagComparison.FirstIsNewer;
+      if (tagA.includes('-') && !tagB.includes('-')) return TagComparison.SecondIsNewer;
+      return compareTags(
+        tagA.slice(tagA.indexOf('-rc') + 3),
+        tagB.slice(tagB.indexOf('-rc') + 3),
+        depth + 1,
+      );
+    }
+  }
+}
+
+export async function getAvailableTags(repo: 'Conduit' | 'Conduit-UI') {
+  const MIN_SUPPORTED_VERSION = 0.15;
+  const res = await axios.get(
+    `https://api.github.com/repos/ConduitPlatform/${repo}/releases`,
+    { headers: { Accept: 'application/vnd.github.v3+json' } },
+  );
+  const releases: string[] = [];
+  const rcReleases: string[] = [];
+  res.data.forEach((release: any) => {
+    if (!release.tag_name.startsWith('v')) return;
+    if (parseFloat(release.tag_name.slice(1)) < MIN_SUPPORTED_VERSION) return;
+    if (release.tag_name.indexOf('-') === -1) {
+      releases.push(release.tag_name);
+    } else {
+      rcReleases.push(release.tag_name);
+    }
+  });
+  releases.sort().reverse();
+  rcReleases.sort().reverse();
+  releases.push(...rcReleases);
+  if (releases.length === 0) {
+    CliUx.ux.error(`No supported ${repo} versions available`, { exit: -1 });
+  }
+  return releases;
+}
+
+export async function selectConduitTag(
+  conduitTags: string[],
+  userConfig: boolean,
+  explicitTag?: string,
+) {
+  if (explicitTag) {
+    await assertValidConduitTag(conduitTags, explicitTag);
+    return explicitTag;
+  } else {
+    let conduitTag = '';
+    if (!userConfig) {
+      conduitTag = conduitTags[0];
+    } else {
+      while (!conduitTags.includes(conduitTag)) {
+        conduitTag = await CliUx.ux.prompt('Specify your desired Conduit version', {
+          default: conduitTags[0],
+        });
+        if (!conduitTags.includes(conduitTag)) {
+          CliUx.ux.log(`Please choose a valid target tag. Example: ${conduitTags[0]}\n`);
+        }
+      }
+    }
+    return conduitTag;
+  }
+}
+
+export async function getMatchingUiTag(conduitTag: string, uiTags: string[]) {
+  // Find Matching Ui Tag
+  const baseVersion = parseFloat(conduitTag.slice(1));
+  const pointReleases = uiTags.filter(tag => {
+    const targetMajor = conduitTag.slice(baseVersion < 1 ? 3 : 1);
+    const tagMajor = tag.slice(baseVersion < 1 ? 3 : 1);
+    return parseInt(targetMajor) === parseInt(tagMajor);
+  });
+  pointReleases.sort().reverse();
+  const stableReleases: string[] = [];
+  const rcReleases: string[] = [];
+  pointReleases.forEach(r => {
+    if (r.includes('-')) {
+      rcReleases.push(r);
+    } else {
+      stableReleases.push(r);
+    }
+  });
+  if (stableReleases.length > 0) {
+    return pointReleases[0];
+  } else if (rcReleases.length > 0) {
+    return rcReleases[0];
+  } else {
+    CliUx.ux.error(
+      `Could not locate a compatible Conduit UI release for Conduit ${conduitTag}`,
+      { exit: -1 },
+    );
+  }
+}
+
+export function assertValidConduitTag(conduitTags: string[], targetTag: string) {
+  if (!conduitTags.includes(targetTag)) {
+    CliUx.ux.error(`Unsupported Conduit tag '${targetTag}' provided!`, { exit: -1 });
+  }
+}
+
+// Memes
+export function abortAsFriends() {
+  const abortLines = [
+    'Alright then, see you around handsome 😘',
+    `Don't be a stranger! 👋`,
+    'After a while 🐊',
+  ];
+  CliUx.ux.log(abortLines[Math.floor(Math.random() * abortLines.length)]);
+  CliUx.ux.exit(0);
+}
+
+export function abortAsEnemies() {
+  const abortLines = [
+    'Hey, make up your mind buddy! 🤔',
+    'I am sworn to carry your burdens... 🙄',
+    'Pathetic! How dare you disturb my slumber over this? 🧞',
+  ];
+  CliUx.ux.log(abortLines[Math.floor(Math.random() * abortLines.length)]);
+  CliUx.ux.exit(0);
 }

--- a/src/docker/Docker.ts
+++ b/src/docker/Docker.ts
@@ -21,4 +21,18 @@ export class Docker {
       return container.Names.includes(`/${name}`);
     });
   }
+
+  async listVolumes(nameSelect: string) {
+    return this.docker
+      .listVolumes({ filters: { name: [nameSelect] } })
+      .then(v => v.Volumes.map(info => info.Name));
+  }
+
+  async removeVolume(name: string) {
+    const volume = this.docker.getVolume(name);
+    return volume
+      .remove()
+      .then(_ => true)
+      .catch(_ => false);
+  }
 }


### PR DESCRIPTION
This PR introduces a whole lot of changes, refactors, features and generally greatly improves the overall experience around deploy.

To keep things concise, this introduces the following:
- Support for v0.15^
- Support for managing persistent volumes
- improved dialog flow
- deploy:update command
- deploy:setup may now handles replacing existing deployment
- deploy:setup can downgroade existing deployment if explicitly requested (with data wipe)
- fixed docker compose v2 for MacOS

**Limitations:**
Multiple deployments are no longer supported.
Minimum Conduit version supported bumped to v0.15 (although we could technically support older majors by creating updated compose files for them).