### PR TITLE
fix(deploy): update failing on ui-only updates, windows docker detection

### DIFF
--- a/src/commands/deploy/setup.ts
+++ b/src/commands/deploy/setup.ts
@@ -79,7 +79,7 @@ export class DeploySetup extends Command {
           'Do you wish to restart your already running deployment?',
         );
       } else {
-        start = await booleanPrompt('Do you wish to start your deployment?');
+        start = await booleanPrompt('Do you wish to start your deployment?', 'yes');
       }
       if (!start) abortAsFriends();
       await DeployStart.run();

--- a/src/deploy/utils.ts
+++ b/src/deploy/utils.ts
@@ -50,20 +50,24 @@ function _getActiveDeploymentTag(command: Command, throwOnNull = true) {
       .trim();
     activeTag = activeTag !== '' ? activeTag : undefined;
   } catch {}
-  return activeTag;
-}
-
-export function getActiveDeploymentTag(command: Command) {
-  const activeTag = _getActiveDeploymentTag(command);
-  if (!activeTag) {
-    CliUx.ux.log('No deployment available 😵');
-    CliUx.ux.exit(0);
+  if (throwOnNull && !activeTag) {
+    CliUx.ux.error('No deployment available 😵', { exit: -1 });
   }
   return activeTag;
 }
 
+export function getActiveDeploymentTag(command: Command) {
+  return _getActiveDeploymentTag(command)!;
+}
+
+export function getActiveDeploymentUiTag(command: Command) {
+  const cfgPath = getTargetDeploymentPaths(command).deploymentConfigPath;
+  const activeEnv = fs.readJSONSync(cfgPath);
+  return activeEnv.environment.UI_IMAGE_TAG;
+}
+
 export function getActiveDeploymentTagOrUndefined(command: Command) {
-  return _getActiveDeploymentTag(command);
+  return _getActiveDeploymentTag(command, false);
 }
 
 export function unsetActiveDeployment(command: Command) {
@@ -195,7 +199,9 @@ export async function getMatchingUiTag(conduitTag: string, uiTags: string[]) {
 
 export function assertValidConduitTag(conduitTags: string[], targetTag: string) {
   if (!conduitTags.includes(targetTag)) {
-    CliUx.ux.error(`Unsupported Conduit tag '${targetTag}' provided!`, { exit: -1 });
+    CliUx.ux.error(`Unknown or unsupported Conduit tag '${targetTag}' provided!`, {
+      exit: -1,
+    });
   }
 }
 

--- a/src/docker/dockerCompose/index.ts
+++ b/src/docker/dockerCompose/index.ts
@@ -92,7 +92,10 @@ class DockerCompose {
       this.executablePath = executablePath;
     } else {
       try {
-        const detectedExecPath = execSync(`which ${fallbackExecPath}`).toString().trim();
+        const detectedExecPath =
+          process.platform === 'win32'
+            ? execSync(`where ${fallbackExecPath}`).toString().split('\n')[0] // windows
+            : execSync(`which ${fallbackExecPath}`).toString().trim(); // linux/mac
         this.executablePath = detectedExecPath.endsWith('not found')
           ? fallbackExecPath
           : detectedExecPath;


### PR DESCRIPTION
This PR introduces the following fixes:

- `deploy:update` returning no updates available on UI-only updates
- docker/docker-compose executable detection failing on Windows
- Improved default boolean prompt values