### PR TITLE
feat(deploy): docker availability checks, daemon autostart

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,32 @@
-conduit-cli
-===========
+<div align="center">
+    <br>
+    <a href="https://getconduit.dev" target="_blank"><img src="https://getconduit.dev/conduitLogo.svg" height="80px" alt="logo"/></a>
+    <br/>
+    <h3>The only Backend you'll ever need.</h3>
+</div>
 
-The CLI to help you when developing conduit.
+# Conduit CLI
+
+Conduit's CLI is a multipurpose tool that's meant to facilitate your development experience and speed up your work
+regardless of whether you're deploying a Conduit instance for your project, developing custom modules or even
+contributing to the upstream project in your spare time.
+
+If you treat it right, it's gonna deploy local instances of Conduit for you, provide API client library generation for
+your frontend team, generate some TypeScript code for your custom modules and even handle your laundry... nah, wait I
+thought we were not actually releasing this one until the next release, right?
+
+Anyway, point is, if you're already using Conduit for your projects or 
+simply intend to give it a ride for the first time, you're most likely going to want to use this.
+
+## Requirements
+
+While the use of Docker is not required for every single piece of functionality provided, for most typical use cases
+you're going to [need Docker installed](https://docs.docker.com/get-docker) and configured so that your user is capable
+of utilizing it without superuser privileges.<br />
+For Linux users, this usually means adding your user to the `docker` group.
+
+You're also going to need some form of support for [docker compose](https://docs.docker.com/compose/install/).<br />
+Conduit's CLI supports both v2 and v1. The former comes pre-installed with the latest versions of Docker Desktop.
 
 [![oclif](https://img.shields.io/badge/cli-oclif-brightgreen.svg?style=for-the-badge)](https://oclif.io)
 ![npm (scoped)](https://img.shields.io/npm/v/@conduitplatform/cli?style=for-the-badge)
@@ -13,6 +38,7 @@ The CLI to help you when developing conduit.
 [//]: # ([![License]&#40;https://img.shields.io/npm/l/conduit-cli.svg&#41;]&#40;https://github.com/ConduitPlatform/CLI/blob/main/package.json&#41;)
 
 <!-- toc -->
+* [Conduit CLI](#conduit-cli)
 * [Limitations](#limitations)
 * [Usage](#usage)
 * [Commands](#commands)

--- a/src/commands/deploy/rm.ts
+++ b/src/commands/deploy/rm.ts
@@ -1,5 +1,4 @@
 import { Command, CliUx, Flags } from '@oclif/core';
-import dockerCompose from '../../docker/dockerCompose';
 import { Docker } from '../../docker';
 import { DeployStop } from './stop';
 import {
@@ -25,9 +24,9 @@ export class DeployRemove extends Command {
     }),
   };
 
+  private docker!: Docker;
   private wipeData!: boolean;
   private stickToDefaults!: boolean;
-  private docker!: Docker;
   private composePath!: string;
   private deploymentConfig!: DeploymentConfiguration;
 
@@ -35,7 +34,7 @@ export class DeployRemove extends Command {
     const flags = (await this.parse(DeployRemove)).flags;
     this.wipeData = flags['wipe-data'] ?? false;
     this.stickToDefaults = flags.defaults ?? false;
-    this.docker = Docker.getInstance();
+    this.docker = Docker.getInstance(); // init or fail early
     // Retrieve Target Deployment
     const target = getActiveDeploymentTag(this);
     // Retrieve Compose Files
@@ -75,7 +74,7 @@ export class DeployRemove extends Command {
       await DeployStop.run();
     }
     // Run Docker Compose
-    await dockerCompose
+    await this.docker.compose
       .rm({
         cwd,
         env,

--- a/src/commands/deploy/setup.ts
+++ b/src/commands/deploy/setup.ts
@@ -13,6 +13,7 @@ import {
 import { Setup } from '../../deploy/Setup';
 import { TagComparison } from '../../deploy/types';
 import { booleanPrompt } from '../../utils/cli';
+import { Docker } from '../../docker';
 
 export class DeploySetup extends Command {
   static description = 'Bootstrap a local Conduit deployment';
@@ -33,6 +34,7 @@ export class DeploySetup extends Command {
     const flags = (await this.parse(DeployUpdate)).flags;
     this.userConfiguration = flags.config ?? false;
     this.targetTag = flags.target;
+    Docker.getInstance(); // init or fail early
     // Get Available Conduit Releases
     this.conduitTags = await getAvailableTags('Conduit');
     if (this.targetTag) {

--- a/src/commands/deploy/start.ts
+++ b/src/commands/deploy/start.ts
@@ -1,5 +1,5 @@
 import { Command, CliUx } from '@oclif/core';
-import dockerCompose from '../../docker/dockerCompose';
+import { Docker } from '../../docker';
 import { DeploymentConfiguration } from '../../deploy/types';
 import { getTargetDeploymentPaths } from '../../deploy/utils';
 import * as fs from 'fs-extra';
@@ -10,6 +10,7 @@ export class DeployStart extends Command {
   static description = 'Bring up your local Conduit deployment';
 
   async run() {
+    Docker.getInstance(); // init or fail early
     await DeployStart.startDeployment(this);
   }
 
@@ -18,6 +19,7 @@ export class DeployStart extends Command {
     tag?: string,
     deploymentConfig?: DeploymentConfiguration,
   ) {
+    const docker = Docker.getInstance();
     const {
       manifestPath: cwd,
       envPath,
@@ -39,7 +41,7 @@ export class DeployStart extends Command {
     };
     process.env = processEnv;
     // Run Docker Compose
-    await dockerCompose
+    await docker.compose
       .upAll({
         cwd,
         env,

--- a/src/commands/deploy/stop.ts
+++ b/src/commands/deploy/stop.ts
@@ -1,5 +1,5 @@
 import { Command, CliUx } from '@oclif/core';
-import dockerCompose from '../../docker/dockerCompose';
+import { Docker } from '../../docker';
 import { getTargetDeploymentPaths } from '../../deploy/utils';
 import { DeploymentConfiguration } from '../../deploy/types';
 import * as dotenv from 'dotenv';
@@ -8,9 +8,11 @@ import * as fs from 'fs-extra';
 export class DeployStop extends Command {
   static description = 'Bring down your local Conduit deployment';
 
+  private docker!: Docker;
   private deploymentConfig!: DeploymentConfiguration;
 
   async run() {
+    this.docker = Docker.getInstance(); // init or fail early
     // Retrieve Compose Files
     const {
       manifestPath: cwd,
@@ -29,7 +31,7 @@ export class DeployStop extends Command {
     };
     process.env = processEnv;
     // Run Docker Compose
-    await dockerCompose
+    await this.docker.compose
       .stop({
         cwd,
         env,

--- a/src/commands/deploy/update.ts
+++ b/src/commands/deploy/update.ts
@@ -13,6 +13,7 @@ import { booleanPrompt } from '../../utils/cli';
 import { DeployRemove } from './rm';
 import { DeployStart } from './start';
 import { Setup } from '../../deploy/Setup';
+import { Docker } from '../../docker';
 
 export class DeployUpdate extends Command {
   static description = 'Update your local Conduit deployment';
@@ -32,6 +33,7 @@ export class DeployUpdate extends Command {
     const flags = (await this.parse(DeployUpdate)).flags;
     const userConfiguration = flags.config ?? false;
     const targetTag = flags.target;
+    Docker.getInstance(); // init or fail early
     // Retrieve Target Deployment
     const currentConduitTag = getActiveDeploymentTag(this);
     // Get Available Conduit Releases

--- a/src/docker/Docker.ts
+++ b/src/docker/Docker.ts
@@ -1,13 +1,19 @@
 import Dockerode = require('dockerode');
+import { execSync } from 'child_process';
+import { CliUx } from '@oclif/core';
+import { DockerCompose } from './dockerCompose';
 
 export class Docker {
   private static _instance?: Docker;
   private readonly docker: Dockerode;
+  readonly compose: DockerCompose;
 
   private constructor() {
+    this.assertAvailable();
     this.docker = new Dockerode({
       socketPath: process.env.DOCKER_SOCKET ?? '/var/run/docker.sock',
     });
+    this.compose = new DockerCompose();
   }
 
   static getInstance() {
@@ -34,5 +40,59 @@ export class Docker {
       .remove()
       .then(_ => true)
       .catch(_ => false);
+  }
+
+  private assertAvailable() {
+    let dockerInstalled = false;
+    try {
+      const detectedExec =
+        process.platform === 'win32'
+          ? execSync('where docker').toString().split('\n')[0] // windows
+          : execSync('which docker').toString().trim(); // linux/mac
+      dockerInstalled = !detectedExec.endsWith('not found');
+    } catch {}
+    if (!dockerInstalled) {
+      CliUx.ux.error('Could not detect Docker executable. Is Docker installed?');
+      process.exit(-1);
+    }
+    const dockerRunning = () => {
+      try {
+        execSync('docker stats --no-stream', { stdio: 'pipe' });
+        return true;
+      } catch {
+        return false;
+      }
+    };
+    if (!dockerRunning()) {
+      switch (process.platform) {
+        case 'darwin':
+          CliUx.ux.log('Starting Docker daemon...');
+          try {
+            execSync('open /Applications/Docker.app');
+          } catch {}
+          break;
+        case 'linux':
+        case 'win32':
+          // TODO
+          break;
+      }
+      let retries = 20; // 20s
+      while (!dockerRunning() && retries > 0) {
+        waitSync(1000);
+        retries -= 1;
+      }
+    }
+    if (!dockerRunning()) {
+      CliUx.ux.error('Could not start Docker. Please start Docker daemon and retry.');
+      process.exit(-1);
+    }
+  }
+}
+
+function waitSync(ms: number) {
+  const start = Date.now();
+  let now = start;
+  while (now - start < ms) {
+    now = Date.now();
   }
 }

--- a/src/docker/dockerCompose/index.ts
+++ b/src/docker/dockerCompose/index.ts
@@ -4,7 +4,6 @@ import { spawn, execSync } from 'child_process';
 import { parse as yamlParse } from 'yaml';
 import mapPorts from './map-ports';
 import { CliUx } from '@oclif/core';
-import { Docker } from '../Docker';
 
 export interface IDockerComposeOptions {
   cwd?: string;

--- a/src/docker/dockerCompose/index.ts
+++ b/src/docker/dockerCompose/index.ts
@@ -4,6 +4,7 @@ import { spawn, execSync } from 'child_process';
 import { parse as yamlParse } from 'yaml';
 import mapPorts from './map-ports';
 import { CliUx } from '@oclif/core';
+import { Docker } from '../Docker';
 
 export interface IDockerComposeOptions {
   cwd?: string;
@@ -81,26 +82,26 @@ export type DockerComposePsResult = {
   }>;
 };
 
-class DockerCompose {
+export class DockerCompose {
   private readonly composeVersion = 1 | 2;
   private readonly executablePath: string;
 
   constructor(composeVersion?: 1 | 2, executablePath?: string) {
-    const fallbackExecPath = this.composeVersion === 1 ? 'docker-compose' : 'docker';
+    const fallbackExec = this.composeVersion === 1 ? 'docker-compose' : 'docker';
     this.composeVersion = composeVersion ?? this.inferComposeVersion();
     if (executablePath) {
       this.executablePath = executablePath;
     } else {
       try {
-        const detectedExecPath =
+        const detectedExec =
           process.platform === 'win32'
-            ? execSync(`where ${fallbackExecPath}`).toString().split('\n')[0] // windows
-            : execSync(`which ${fallbackExecPath}`).toString().trim(); // linux/mac
-        this.executablePath = detectedExecPath.endsWith('not found')
-          ? fallbackExecPath
-          : detectedExecPath;
+            ? execSync(`where ${fallbackExec}`).toString().split('\n')[0] // windows
+            : execSync(`which ${fallbackExec}`).toString().trim(); // linux/mac
+        this.executablePath = detectedExec.endsWith('not found')
+          ? fallbackExec
+          : detectedExec;
       } catch {
-        this.executablePath = fallbackExecPath;
+        this.executablePath = fallbackExec;
       }
     }
   }
@@ -116,7 +117,7 @@ class DockerCompose {
       execSync('docker-compose --help');
       return 1;
     } catch {}
-    CliUx.ux.log('Could not detect docker compose version. Is docker compose installed?');
+    CliUx.ux.log('Could not detect Docker Compose version. Is Docker Compose installed?');
     process.exit(-1);
   }
 
@@ -580,6 +581,3 @@ class DockerCompose {
     }
   }
 }
-
-const dockerCompose = new DockerCompose();
-export default dockerCompose;


### PR DESCRIPTION
This PR introduces checks for Docker availability.
Checks only added in commands that require Docker.
Checks take place early on so as to abort before any user input.

On macOS, if Docker is available, but not running, CLI will attempt to automatically start the Docker daemon.
I'll follow up with a proper implementation for Linux on a followup PR as that would be init system-specific and most likely fail anyway due to systemctl permissions.

Users without a Docker installation or a prestarted Docker daemon, and for whom auto-start fails, can now expect to come across a human readable error prompting them to install Docker or start its daemon, regardless of platform.

I had to resort to some meh-tier Docker/DockerCompose (class) refactors due to an `oclif` bug resulting in code executing during builds (`oclif manifest`).

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [X] A convincing reason for adding this feature <!-- to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it -->
