### PR TITLE
feat(deploy): ui improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@graphql-codegen/typescript-vue-urql": "^2.2.12",
     "@openapitools/openapi-generator-cli": "^2.5.1",
     "axios": "^0.24.0",
+    "chalk": "4.1.2",
     "dockerode": "^3.3.2",
     "dotenv": "^16.0.1",
     "fs-extra": "^10.0.0",

--- a/src/commands/deploy/rm.ts
+++ b/src/commands/deploy/rm.ts
@@ -65,7 +65,7 @@ export class DeployRemove extends Command {
         'You may remove your existing deployment while preserving persistent data volumes.',
       );
       this.wipeData = await booleanPrompt(
-        'Do you wish to permanently wipe persistent data? 🗑️',
+        'Do you wish to permanently wipe persistent data? 🗑️ ',
         'no',
       );
     }

--- a/src/commands/deploy/setup.ts
+++ b/src/commands/deploy/setup.ts
@@ -14,6 +14,7 @@ import { Setup } from '../../deploy/Setup';
 import { TagComparison } from '../../deploy/types';
 import { booleanPrompt } from '../../utils/cli';
 import { Docker } from '../../docker';
+import chalk = require('chalk');
 
 export class DeploySetup extends Command {
   static description = 'Bootstrap a local Conduit deployment';
@@ -53,6 +54,7 @@ export class DeploySetup extends Command {
       const setup = new Setup(this, this.userConfiguration, conduitTag);
       await setup.setupEnvironment();
       await DeployStart.startDeployment(this, conduitTag, setup.deploymentConfig);
+      await this.displayDefaultCredentials();
       // Store Deployment Configuration After Successful Start
       await setup.storeDeploymentConfig();
     }
@@ -88,5 +90,19 @@ export class DeploySetup extends Command {
       if (!start) abortAsFriends();
       await DeployStart.run();
     }
+  }
+
+  private async displayDefaultCredentials() {
+    CliUx.ux.log(
+      `\n\n 🤫 ${chalk
+        .bgRgb(153, 102, 255)
+        .bold.underline('   Default Credentials   ')} 🔑`,
+    );
+    CliUx.ux.log(
+      `${chalk.greenBright('       Username:  ')}${chalk.magentaBright('admin')}`,
+    );
+    CliUx.ux.log(
+      `${chalk.greenBright('       Password:  ')}${chalk.magentaBright('admin')}`,
+    );
   }
 }

--- a/src/utils/sleep.ts
+++ b/src/utils/sleep.ts
@@ -1,0 +1,5 @@
+export function sleep(ms: number) {
+  return new Promise(resolve => {
+    setTimeout(resolve, ms);
+  });
+}


### PR DESCRIPTION
This PR makes it so `deploy:start` waits for Conduit-UI's Next.js server to become serving before redirecting the user's browser.
It also displays default credentials during initial deployment setup (`deploy:setup`).
Added chalk for colorized output.

Example Output:
<img width="125" alt="Screenshot 2022-12-02 at 12 01 03" src="https://user-images.githubusercontent.com/1786609/205267245-75ce2811-62e3-4fa7-a6da-325b8acfca22.png">
﻿
**What kind of change does this PR introduce?** <!--(check at least one)-->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)