### PR TITLE
feat(cli): available update hints

### DIFF
--- a/src/commands/cli/update.ts
+++ b/src/commands/cli/update.ts
@@ -2,11 +2,10 @@ import { CliUx, Command } from '@oclif/core';
 import { get } from 'https';
 import { mkdir } from 'fs/promises';
 import axios from 'axios';
-import * as fs from 'fs';
+import * as fs from 'fs-extra';
 import * as path from 'path';
 import { InstallationType } from '../../interfaces';
 import { getInstallationType } from '../../utils/installation';
-
 const { spawn } = require('child_process');
 import chalk = require('chalk');
 
@@ -19,15 +18,17 @@ export class CliUpdate extends Command {
   private readonly scriptPath = path.join(this.scriptDownloadDir, 'get-conduit.sh');
 
   async run() {
+    // Update Checks
     if (!CliUpdate.platformSupported()) {
       CliUx.ux.log('Self-managed CLI updates are not supported on your platform');
       CliUx.ux.exit(-1);
     }
-    if (!(await CliUpdate.updateAvailable(this))) {
+    if (!(await CliUpdate.updateAvailable(this, false))) {
       CliUx.ux.log('No CLI updates available... 👍');
       CliUx.ux.exit(0);
     }
     this.handleInstallationType();
+    // CLI Update (System)
     await this.downloadScript().catch(() => {
       CliUx.ux.error('Failed to retrieve update script.');
       CliUx.ux.exit(-1);
@@ -43,16 +44,38 @@ export class CliUpdate extends Command {
     return ['linux', 'darwin'].includes(process.platform);
   }
 
-  static async updateAvailable(command: Command) {
+  static async updateAvailable(command: Command, acceptCached = true) {
     const thisVersion = `v${command.config.version}`;
+    const latestVersion = await CliUpdate.getLatestVersion(command, acceptCached);
+    return thisVersion !== latestVersion;
+  }
+
+  private static async getLatestVersion(command: Command, acceptCached = true) {
+    let cached: { version: string; timestamp: Date } | undefined;
+    const versionCacheFile = path.join(
+      command.config.cacheDir,
+      'latest-gh-version-cache',
+    );
+    if (acceptCached) {
+      cached = await fs.readJSON(versionCacheFile).catch(() => undefined);
+      if (cached) {
+        cached.timestamp = new Date(cached.timestamp);
+        const thirtyMinutesAgo = new Date().getTime() - 30 * 60 * 1000;
+        if (cached.timestamp.getTime() > thirtyMinutesAgo) {
+          return cached.version;
+        }
+      }
+    }
     const ghRes = await axios
       .get('https://api.github.com/repos/ConduitPlatform/CLI/releases/latest')
       .catch(() => {
-        CliUx.ux.error('Could not retrieve latest CLI release info.');
+        CliUx.ux.error('Could not retrieve latest CLI release info. Try again later.');
         CliUx.ux.exit(-1);
       });
     const latestVersion = ghRes.data.tag_name;
-    return thisVersion !== latestVersion;
+    cached = { version: latestVersion, timestamp: new Date() };
+    await fs.writeJson(versionCacheFile, cached);
+    return latestVersion;
   }
 
   static async displayUpdateHint(command: Command) {

--- a/src/commands/cli/update.ts
+++ b/src/commands/cli/update.ts
@@ -1,10 +1,13 @@
-import { Command, CliUx } from '@oclif/core';
+import { CliUx, Command } from '@oclif/core';
 import { get } from 'https';
 import { mkdir } from 'fs/promises';
 import axios from 'axios';
 import * as fs from 'fs';
 import * as path from 'path';
 const { spawn } = require('child_process');
+import chalk = require('chalk');
+import { InstallationType } from '../../interfaces';
+import { getInstallationType } from '../../utils/installation';
 
 const SCRIPT_URL = 'https://getconduit.dev/bootstrap';
 
@@ -23,6 +26,7 @@ export class CliUpdate extends Command {
       CliUx.ux.log('No CLI updates available... 👍');
       CliUx.ux.exit(0);
     }
+    this.handleInstallationType();
     await this.downloadScript().catch(() => {
       CliUx.ux.error('Failed to retrieve update script.');
       CliUx.ux.exit(-1);
@@ -48,6 +52,15 @@ export class CliUpdate extends Command {
       });
     const latestVersion = ghRes.data.tag_name;
     return thisVersion !== latestVersion;
+  }
+
+  private handleInstallationType() {
+    const installationType = getInstallationType();
+    if (installationType === InstallationType.SYSTEM) return;
+    if (installationType === InstallationType.NPM) {
+      CliUx.ux.log(chalk.magentaBright('Your CLI updates are handled by npm.'));
+    }
+    process.exit(0);
   }
 
   private removeScript() {

--- a/src/commands/cli/update.ts
+++ b/src/commands/cli/update.ts
@@ -4,10 +4,11 @@ import { mkdir } from 'fs/promises';
 import axios from 'axios';
 import * as fs from 'fs';
 import * as path from 'path';
-const { spawn } = require('child_process');
-import chalk = require('chalk');
 import { InstallationType } from '../../interfaces';
 import { getInstallationType } from '../../utils/installation';
+
+const { spawn } = require('child_process');
+import chalk = require('chalk');
 
 const SCRIPT_URL = 'https://getconduit.dev/bootstrap';
 
@@ -52,6 +53,19 @@ export class CliUpdate extends Command {
       });
     const latestVersion = ghRes.data.tag_name;
     return thisVersion !== latestVersion;
+  }
+
+  static async displayUpdateHint(command: Command) {
+    const updateAvailable = (await CliUpdate.updateAvailable(command).catch()) ?? false;
+    if (!updateAvailable) return;
+    const installationType = getInstallationType();
+    CliUx.ux.log(`\n 📣 ${chalk.bgGreen.bold('   CLI Update Available   ')} 📣`);
+    if (installationType === InstallationType.SYSTEM) {
+      CliUx.ux.log(` ${chalk.italic('    Run: conduit cli update')} `);
+    } else if (installationType === InstallationType.NPM) {
+      CliUx.ux.log(` ${chalk.italic('        Install via npm')} `);
+    }
+    CliUx.ux.log('');
   }
 
   private handleInstallationType() {

--- a/src/commands/deploy/rm.ts
+++ b/src/commands/deploy/rm.ts
@@ -1,6 +1,7 @@
 import { Command, CliUx, Flags } from '@oclif/core';
 import { Docker } from '../../docker';
 import { DeployStop } from './stop';
+import { CliUpdate } from '../cli/update';
 import {
   getTargetDeploymentPaths,
   getActiveDeploymentTag,
@@ -31,6 +32,7 @@ export class DeployRemove extends Command {
   private deploymentConfig!: DeploymentConfiguration;
 
   async run() {
+    await CliUpdate.displayUpdateHint(this);
     const flags = (await this.parse(DeployRemove)).flags;
     this.wipeData = flags['wipe-data'] ?? false;
     this.stickToDefaults = flags.defaults ?? false;

--- a/src/commands/deploy/setup.ts
+++ b/src/commands/deploy/setup.ts
@@ -1,6 +1,7 @@
 import { CliUx, Command, Flags } from '@oclif/core';
 import { DeployStart } from './start';
 import { DeployUpdate } from './update';
+import { CliUpdate } from '../cli/update';
 import {
   abortAsFriends,
   assertValidConduitTag,
@@ -32,6 +33,7 @@ export class DeploySetup extends Command {
   private conduitTags!: string[];
 
   async run() {
+    await CliUpdate.displayUpdateHint(this);
     const flags = (await this.parse(DeployUpdate)).flags;
     this.userConfiguration = flags.config ?? false;
     this.targetTag = flags.target;

--- a/src/commands/deploy/start.ts
+++ b/src/commands/deploy/start.ts
@@ -1,5 +1,6 @@
 import { Command, CliUx } from '@oclif/core';
 import { Docker } from '../../docker';
+import { CliUpdate } from '../cli/update';
 import { DeploymentConfiguration } from '../../deploy/types';
 import { getTargetDeploymentPaths } from '../../deploy/utils';
 import { sleep } from '../../utils/sleep';
@@ -13,6 +14,7 @@ export class DeployStart extends Command {
   static description = 'Bring up your local Conduit deployment';
 
   async run() {
+    await CliUpdate.displayUpdateHint(this);
     Docker.getInstance(); // init or fail early
     await DeployStart.startDeployment(this);
   }

--- a/src/commands/deploy/start.ts
+++ b/src/commands/deploy/start.ts
@@ -69,7 +69,7 @@ export class DeployStart extends Command {
         .then(() => (uiServing = true))
         .catch(() => {
           if (!warnedOnce) {
-            CliUx.ux.log(chalk.yellow('    This may take a while...'));
+            CliUx.ux.log(chalk.italic('    This may take a while...'));
             warnedOnce = true;
           }
           sleep(1000);

--- a/src/commands/deploy/stop.ts
+++ b/src/commands/deploy/stop.ts
@@ -1,5 +1,6 @@
 import { Command, CliUx } from '@oclif/core';
 import { Docker } from '../../docker';
+import { CliUpdate } from '../cli/update';
 import { getTargetDeploymentPaths } from '../../deploy/utils';
 import { DeploymentConfiguration } from '../../deploy/types';
 import * as dotenv from 'dotenv';
@@ -12,6 +13,7 @@ export class DeployStop extends Command {
   private deploymentConfig!: DeploymentConfiguration;
 
   async run() {
+    await CliUpdate.displayUpdateHint(this);
     this.docker = Docker.getInstance(); // init or fail early
     // Retrieve Compose Files
     const {

--- a/src/commands/deploy/update.ts
+++ b/src/commands/deploy/update.ts
@@ -12,6 +12,7 @@ import {
 import { booleanPrompt } from '../../utils/cli';
 import { DeployRemove } from './rm';
 import { DeployStart } from './start';
+import { CliUpdate } from '../cli/update';
 import { Setup } from '../../deploy/Setup';
 import { Docker } from '../../docker';
 
@@ -30,6 +31,7 @@ export class DeployUpdate extends Command {
   private wipeData: boolean = false;
 
   async run() {
+    await CliUpdate.displayUpdateHint(this);
     const flags = (await this.parse(DeployUpdate)).flags;
     const userConfiguration = flags.config ?? false;
     const targetTag = flags.target;

--- a/src/commands/generateClient/graphql.ts
+++ b/src/commands/generateClient/graphql.ts
@@ -1,4 +1,5 @@
 import { Command, Flags, CliUx } from '@oclif/core';
+import { CliUpdate } from '../cli/update';
 import { generate } from '@graphql-codegen/cli';
 import { isEmpty } from 'lodash';
 import { Requests } from '../../http/http';
@@ -60,6 +61,7 @@ export class GenerateClientGraphql extends Command {
   ];
 
   async run() {
+    await CliUpdate.displayUpdateHint(this);
     const { adminUrl, appUrl, masterKey } = await recoverApiConfigSafe(this);
     const parsedFlags = (await this.parse(GenerateClientGraphql)).flags;
     CliUx.ux.action.start('Recovering credentials');

--- a/src/commands/generateClient/rest.ts
+++ b/src/commands/generateClient/rest.ts
@@ -1,4 +1,5 @@
 import { Command, Flags, CliUx } from '@oclif/core';
+import { CliUpdate } from '../cli/update';
 import { promptWithOptions } from '../../utils/cli';
 import {
   getClientType,
@@ -23,6 +24,7 @@ export class GenerateClientRest extends Command {
   private supportedClientTypes: string[] = [];
 
   async run() {
+    await CliUpdate.displayUpdateHint(this);
     const javaVersion = this.getJavaVersion();
     if (!javaVersion) {
       // This is a temporary solution until we figure out the best way to approach this using Docker

--- a/src/commands/generateSchema.ts
+++ b/src/commands/generateSchema.ts
@@ -1,4 +1,5 @@
 import { Command, CliUx } from '@oclif/core';
+import { CliUpdate } from './cli/update';
 import { getRequestClient } from '../utils/requestUtils';
 import { Requests } from '../http/http';
 import { generateSchema } from '../generators/Schema/Schema.generator';
@@ -16,6 +17,7 @@ Generating schemas
   static args = [{ name: 'path' }];
 
   async run() {
+    await CliUpdate.displayUpdateHint(this);
     const { args } = await this.parse(GenerateSchema);
     CliUx.ux.action.start('Recovering credentials');
     let requestClient: Requests;

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,4 +1,5 @@
 import { Command, Flags, CliUx } from '@oclif/core';
+import { CliUpdate } from './cli/update';
 import { Requests } from '../http/http';
 import { recoverApiConfig, storeConfiguration } from '../utils/requestUtils';
 import { booleanPrompt } from '../utils/cli';
@@ -22,6 +23,7 @@ Login Successful!
   };
 
   async run() {
+    await CliUpdate.displayUpdateHint(this);
     const { flags } = await this.parse(Init);
     let adminUrl, appUrl, _masterKey;
     if (flags.relogin) {

--- a/src/interfaces/InstallationType.ts
+++ b/src/interfaces/InstallationType.ts
@@ -1,0 +1,4 @@
+export enum InstallationType {
+  SYSTEM,
+  NPM,
+}

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -1,1 +1,2 @@
 export * from './axios';
+export * from './InstallationType';

--- a/src/utils/installation.ts
+++ b/src/utils/installation.ts
@@ -1,0 +1,9 @@
+import { InstallationType } from '../interfaces';
+
+export function getInstallationType(): InstallationType {
+  if (process.env.npm_execpath) {
+    return InstallationType.NPM;
+  } else {
+    return InstallationType.SYSTEM;
+  }
+}


### PR DESCRIPTION
This PR introduces non-intrusive update availability hints across all commands.
An update availability check runs at the start of each command, logging an update hint if the user's CLI is outdated.

The hint suggests the use of `cli:update` to update to the latest CLI version, which in turn pulls and runs the same remote script the user used to initially install the CLI, allowing for the latest installation script to be used regardless of the version the user is updating from.

There's no prompt asking for an update, we simply log the update availability so that the users are aware of its existence, therefore likely to stay updated, or at the very least perform the update before reporting an issue.

Latest version is cached for 30mins so as not to spam the GitHub API.

The CLI does not handle npm updates.
When installed through npm, it simply logs the update availability.

Example:
<img width="427" alt="Screenshot 2022-12-04 at 19 39 04" src="https://user-images.githubusercontent.com/1786609/205506462-eb5d1fe3-45cb-46f6-a256-b335abb10269.png">

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [X] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [ ] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [X] A convincing reason for adding this feature <!-- to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it -->
